### PR TITLE
Use exec to spawn java -jar

### DIFF
--- a/tools/springboot/springboot.bzl
+++ b/tools/springboot/springboot.bzl
@@ -184,7 +184,7 @@ path=%path%
 jar=%jar%
 
 # assemble the command
-cmd="${java_cmd} %jvm_flags% ${JAVA_OPTS} -jar ${path}/${jar} ${main_args}"
+cmd="exec ${java_cmd} %jvm_flags% ${JAVA_OPTS} -jar ${path}/${jar} ${main_args}"
 
 echo "Running ${cmd}"
 echo "In directory $(pwd)"


### PR DESCRIPTION
By using exec to run the java process, it allows for the java process to take over the current process and handle sent signals, such as from parent processes when spawned programatically.