### PR TITLE
add launcher_script attribute to springboot rule so user can provide script for bazel run

### DIFF
--- a/examples/helloworld/BUILD
+++ b/examples/helloworld/BUILD
@@ -67,10 +67,12 @@ springboot(
     duplicate_class_allowlist = "helloworld_dupeclass_allowlist.txt",
 
     # Specify optional JVM args to use when the application is launched with 'bazel run'
-    jvm_flags = "-Dcustomprop=gold",
+    jvm_flags = "-Dcustomprop=gold -DcustomProp2=silver",
 
     # data files can be made available in the working directory for when the app is launched with bazel run
     data = ["example_data.txt"],
+
+    launcher_script = "custom_launcher_script.sh",
 
     # if you have conflicting classes in dependency jar files, you can define the order in which the jars are loaded
     #  https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-executable-jar-format.html#executable-jar-war-index-files-classpath

--- a/examples/helloworld/custom_launcher_script.sh
+++ b/examples/helloworld/custom_launcher_script.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+# Custom Launcher Script for launching a SpringBoot application with 'bazel run'
+# this is wired up in the springboot rule (the launcher_script attribute)
+
+echo "USING A CUSTOM LAUNCHER SCRIPT AS A DEMO (see custom_launcher_script.sh)"
+
+# The following environment variables will be set, and can be used for scripting:
+#  LABEL_PATH=examples/helloworld
+#  SPRINGBOOTJAR_FILENAME=helloworld.jar
+#  JVM_FLAGS="-Dcustomprop=gold  -DcustomProp2=silver"
+
+# soon we will use one of the jdk locations already known to Bazel, see Issue #16
+if [ -z ${JAVA_HOME} ]; then
+  java_cmd="$(which java)"
+else
+  java_cmd="${JAVA_HOME}/bin/java"
+fi
+
+if [ -z "${java_cmd}" ]; then
+  echo "ERROR: no java found, either set JAVA_HOME or add the java executable to your PATH"
+  exit 1
+fi
+echo "Using Java at ${java_cmd}"
+${java_cmd} -version
+echo ""
+
+# java args
+echo "Using JAVA_OPTS from the environment: ${JAVA_OPTS}"
+echo "Using jvm_flags from the BUILD file: ${JVM_FLAGS}"
+
+# main args
+main_args="$@"
+
+# spring boot jar; these are replaced by the springboot starlark code:
+path=${LABEL_PATH}
+jar=${SPRINGBOOTJAR_FILENAME}
+echo "JAR FILE: ${path}/${jar}"
+
+# assemble the command
+# use exec so that we can pass signals to the underlying process (https://github.com/salesforce/rules_spring/issues/91)
+cmd="exec ${java_cmd} ${JVM_FLAGS} ${JAVA_OPTS} -jar ${path}/${jar} ${main_args}"
+
+echo "Running ${cmd}"
+echo "In directory $(pwd)"
+echo ""
+echo "You can also run from the root of the repo:"
+echo "java -jar bazel-bin/${path}/${jar}"
+echo ""
+
+${cmd}

--- a/examples/helloworld/src/main/java/com/sample/SampleAutoConfiguration.java
+++ b/examples/helloworld/src/main/java/com/sample/SampleAutoConfiguration.java
@@ -16,9 +16,9 @@ public class SampleAutoConfiguration {
 
     /**
      * Shows how you can catch an OS signal. This is a good test of the launcher script See
-     * https://github.com/salesforce/rules_spring/issues/91 
-     * The only signal that SignalUtils attaches to is 2 (interrupt). kill -2 [pid] 
-     * 
+     * https://github.com/salesforce/rules_spring/issues/91
+     * The only signal that SignalUtils attaches to is 2 (interrupt). kill -2 [pid]
+     *
      * I am not a big fan of HelloWorld having these edge case demos, but is the only place
      * we have right now.
      */
@@ -26,6 +26,7 @@ public class SampleAutoConfiguration {
         @Override
         public void run() {
             System.out.println("Caught an Interupt signal.");
+            System.exit(0);
         }
     }
 }

--- a/springboot/BUILD
+++ b/springboot/BUILD
@@ -16,6 +16,8 @@ exports_files([
     "check_dupe_classes.py",
     "write_gitinfo_properties.sh",
     "write_manifest.sh",
+    "write_launcherenv.sh",
+    "default_launcher_script.sh",
     "dupe_class_jar_allowlist.txt",
     "empty.txt",
 ])

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -142,6 +142,21 @@ export JAVA_OPTS='-Dcustomprop=silver'
 bazel run //examples/helloworld
 ```
 
+If this is not enough, you may completely replace the launcher script for advanced use cases.
+Note that this customization only affects the startup when invoked from *bazel run*.
+Make a copy of [default_launcher_script.sh](default_launcher_script.sh) into your package,
+  and make changes as necessary.
+Then pass it via the *launcher_script* attribute, like this:
+
+```starlark
+springboot(
+    name = "helloworld",
+    boot_app_class = "com.sample.SampleMain",
+    java_library = ":helloworld_lib",
+    launcher_script = "my_custom_launcher_script.sh",
+)
+```
+
 ### Other Rule Attributes
 
 The Spring Boot rule supports other attributes for use in the BUILD file:

--- a/springboot/default_launcher_script.sh
+++ b/springboot/default_launcher_script.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+# Launcher Script for launching a SpringBoot application with 'bazel run'
+
+# The following environment variables will be set, and can be used for scripting:
+#  LABEL_PATH=examples/helloworld
+#  SPRINGBOOTJAR_FILENAME=helloworld.jar
+#  JVM_FLAGS="-Dcustomprop=gold  -DcustomProp2=silver"
+
+# soon we will use one of the jdk locations already known to Bazel, see Issue #16
+if [ -z ${JAVA_HOME} ]; then
+  java_cmd="$(which java)"
+else
+  java_cmd="${JAVA_HOME}/bin/java"
+fi
+
+if [ -z "${java_cmd}" ]; then
+  echo "ERROR: no java found, either set JAVA_HOME or add the java executable to your PATH"
+  exit 1
+fi
+echo "Using Java at ${java_cmd}"
+${java_cmd} -version
+echo ""
+
+# java args
+echo "Using JAVA_OPTS from the environment: ${JAVA_OPTS}"
+echo "Using jvm_flags from the BUILD file: ${JVM_FLAGS}"
+
+# main args
+main_args="$@"
+
+# spring boot jar; these are replaced by the springboot starlark code:
+path=${LABEL_PATH}
+jar=${SPRINGBOOTJAR_FILENAME}
+echo "JAR FILE: ${path}/${jar}"
+
+# assemble the command
+# use exec so that we can pass signals to the underlying process (https://github.com/salesforce/rules_spring/issues/91)
+cmd="exec ${java_cmd} ${JVM_FLAGS} ${JAVA_OPTS} -jar ${path}/${jar} ${main_args}"
+
+echo "Running ${cmd}"
+echo "In directory $(pwd)"
+echo ""
+echo "You can also run from the root of the repo:"
+echo "java -jar bazel-bin/${path}/${jar}"
+echo ""
+
+${cmd}

--- a/springboot/write_gitinfo_properties.sh
+++ b/springboot/write_gitinfo_properties.sh
@@ -14,6 +14,8 @@
 #   to share cache entries for Spring Boot jars. This is a major perf optimization.
 # See //tools/buildstamp/README.md for details.
 
+set -e
+
 # Create the properties file
 GITPROPSFILE=$1
 echo "# git info injected by Bazel build" > $GITPROPSFILE

--- a/springboot/write_launcherenv.sh
+++ b/springboot/write_launcherenv.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) 2017-2021, salesforce.com, inc.
+# All rights reserved.
+# Licensed under the BSD 3-Clause license.
+# For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+#
+
+set -e
+
+SPRINGBOOTJAR_FILENAME=${1}
+LABEL_PATH=${2}
+OUTPUTFILE_PATH=${3}
+FIRST_JVMFLAG_ARG=4
+
+#echo "Generating launcher env to $OUTPUTFILE_PATH"
+
+JVM_FLAGS=""
+i=$FIRST_JVMFLAG_ARG
+while [ "$i" -le "$#" ]; do
+  eval "FLAG=\${$i}"
+  JVM_FLAGS="$JVM_FLAGS $FLAG"
+  i=$((i + 1))
+done
+
+echo "export LABEL_PATH=$LABEL_PATH" > $OUTPUTFILE_PATH
+echo "export SPRINGBOOTJAR_FILENAME=$SPRINGBOOTJAR_FILENAME" >> $OUTPUTFILE_PATH
+echo "export JVM_FLAGS=\"$JVM_FLAGS\"" >> $OUTPUTFILE_PATH

--- a/springboot/write_manifest.sh
+++ b/springboot/write_manifest.sh
@@ -6,6 +6,8 @@
 # For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
 #
 
+set -e
+
 MAINCLASS=$1
 MANIFESTFILE=$2
 FOUND_SPRING_JAR=0


### PR DESCRIPTION
This provides a way for the user to replace the launcher script used when invoking the Spring Boot application via 'bazel run' #92 

There were some gymnastics involved, as there are some variables that need to be substituted in the launcher script. I implemented this by generating an extra env script that provides those values that gets invoked prior to invoking the actual launcher script.