### PR TITLE
add link to the kotlin example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,4 +3,8 @@
 Navigate into our examples directories:
 
 - [Hello World](helloworld): bare bones example
-- [Demo App](demoapp): demonstrates how to use various features in the rule 
+- [Demo App](demoapp): demonstrates how to use various features in the rule
+
+There is also a Kotlin example, which is kept in a separate branch in this repository:
+
+- [KotlinApp](https://github.com/salesforce/rules_spring/tree/examples_kotlin) shows how to use Kotlin with Spring Boot


### PR DESCRIPTION
I created a kotlin springboot example. I didn't want to add in Kotlin in our primary WORKSPACE since most users will not use it. So I put it in a separate branch in this repo. This fixes #84 