### PR TITLE
Extract Spring-Boot-Version from the MANIFEST of a Spring Boot JAR

### DIFF
--- a/springboot/write_manifest.sh
+++ b/springboot/write_manifest.sh
@@ -12,8 +12,10 @@ FOUND_SPRING_JAR=0
 # Looking for the springboot jar injected by springboot.bzl and extracting the version
 for var in "$@"
 do
-  if [[ $var = *"spring-boot-"* ]]; then
-    SPRING_VERSION=$(echo "$var" | rev | cut -c5- | rev | cut -d / -f 4 | cut -d - -f 3)
+  if [[ $var = *"spring-boot-"* ]] || [[ $var = *"spring_boot_"* ]]; then
+    jar xf $var META-INF/MANIFEST.MF
+    SPRING_VERSION=$(grep 'Implementation-Version' META-INF/MANIFEST.MF | cut -d : -f2 | tr -d '[:space:]')
+    rm -rf META-INF
     FOUND_SPRING_JAR=1
     break
   fi


### PR DESCRIPTION
This PR addresses #111. 

The Bash script `write_manifest.sh` extracts the from the file name of the Spring boot dependencies, which is not a reliable source. This PR extracts it from the MANIFEST of a Spring Boot dependency.
This is not super reliable either, maybe we could search all dependencies for `Automatic-Module-Name: spring.boot.starter...` and use this?

Could this fix also be applied to a 2.0.0 branch and released as 2.0.1?