### PR TITLE
first drop of the springboot CLI

### DIFF
--- a/springboot/BUILD
+++ b/springboot/BUILD
@@ -41,6 +41,19 @@ py_test(
     tags = ["manual"],
 )
 
+java_library(
+    name = "springboot_lib",
+    srcs = glob(["src/main/java/**/*.java"]),
+    deps = [],
+)
+
+java_binary(
+    name = "springboot_cli",
+    runtime_deps = [":springboot_lib"],
+    main_class = "com.salesforce.rulesspring.cli.SpringBootInspector",
+)
+
+
 # Enable only when generating the doc, then disable again before releasing. We don't want to require
 # users of the rule to configure stardoc in their workspace. You need to uncomment the WORKSPACE def
 # for this before using.

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -1,10 +1,14 @@
 ## SpringBoot Rule
 
-This implements a Bazel rule for packaging a Spring Boot application as an executable jar file.
-The output of this rule is a jar file that can be copied to production environments and run.
+This implements a Bazel rule for packaging a Spring Boot application as an executable jar file from a Bazel build.
+The output of this rule is a jar file that can be copied to production environments and run as an executable jar.
 
 See the [top-level README](../README.md) for the stanza to add to your *WORKSPACE* file to load the rule.
 The *springboot* rule runs on any version of Bazel 1.2.1 or higher.
+
+:eyes: this package also contains a CLI for inspecting Spring Boot jars after they have been built.
+This can be useful when troubleshooting behavior differences over time due to changing dependencies.
+See [the CLI user guide](cli.md) for details.
 
 ### Use the rule in your BUILD file
 

--- a/springboot/cli.md
+++ b/springboot/cli.md
@@ -1,0 +1,55 @@
+## SpringBoot Jar CLI
+
+In addition to the Bazel rule, this package also contains a CLI for inspecting Spring Boot jars after they have been built.
+This can be useful when troubleshooting behavior differences over time due to changing dependencies.
+The CLI works on any exectuable Spring Boot jar, regardless of whether it was built with Bazel, Maven, or Gradle.
+
+
+### Running the CLI
+
+If you are importing rules_spring into your Bazel workspace, you can access the tool by a pattern like this:
+
+```
+bazel run @rules_spring//springboot:springboot_cli [args]
+```
+
+Otherwise, if you have Bazel, you can run it from this repository:
+
+```
+bazel run //springboot:springboot_cli [args]
+```
+
+For non-Bazel users, a built jar will periodically be added to this directory as _springboot-cli.jar_.
+
+```
+jar -jar springboot-cli.jar [args]
+```
+
+### Inspector
+
+Inspector is used for any operation involving a single Spring Boot jar.
+
+#### Inspector Index
+
+The _index_ operation iterates through the Spring Boot jar and creates an index of the contained files.
+The index is written to file, and the output can be customized to meet the requirements of your analysis work.
+This operation can be useful when trying to investigate issues with dependencies in the application.
+
+If you are building your Spring Boot application with Bazel, this operation is similar in some ways to
+  what can be obtained from Bazel Query.
+Bazel Query will output the set of libraries that are dependencies.
+The _index_ is more detailed though in that it can output exact file sizes and is run on the final
+  Spring Boot jar.
+If you are using *rules_spring* features like *deps_exclude*, the Bazel Query output will be incorrect.
+
+Usage examples:
+```
+# do the default index operation
+bazel run @rules_spring//springboot:springboot_cli inspector index /opt/bazelws/bazel-bin/services/ordering/ordering.jar /tmp/output.txt
+
+# customize the report output; this only writes out the jar files found (L) and will also write the file size of each jar file (Z)
+bazel run @rules_spring//springboot:springboot_cli inspector index /opt/bazelws/bazel-bin/services/ordering/ordering.jar /tmp/output.txt --report LZ
+```
+
+The customizable report output options are implemented in *SpringBootIndexReporter* which is the best place to look for documentation.
+This class is pretty simple, so the code serves as the documentation.

--- a/springboot/src/main/java/com/salesforce/rulesspring/cli/SpringBootInspector.java
+++ b/springboot/src/main/java/com/salesforce/rulesspring/cli/SpringBootInspector.java
@@ -1,0 +1,124 @@
+package com.salesforce.rulesspring.cli;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+
+import com.salesforce.rulesspring.index.SpringBootIndexReporter;
+import com.salesforce.rulesspring.index.IndexOfFiles;
+import com.salesforce.rulesspring.index.SpringBootJarIndexer;
+
+public class SpringBootInspector {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 3) {
+            usage();
+            return;
+        }
+
+        Command cmd = parseArgs(args);
+
+        if ("inspector".equals(cmd.mode)) {
+            File jarFile = new File(cmd.jarFilepath);
+            if (!jarFile.exists()) {
+                System.err.println("ERROR: File "+cmd.jarFilepath+" does not exist.");
+                return;
+            }
+            System.out.println("Spring Boot Jar absolute path: "+jarFile.getAbsolutePath());
+
+            if ("index".equals(cmd.operation)) {
+                File indexFile = new File(cmd.outputPath);
+                if (indexFile.exists()) {
+                    System.err.println("ERROR: File "+indexFile.getAbsolutePath()+" already exists and we don't overwrite files.");
+                    return;
+                }
+                System.out.println("Index output file absolute path: "+indexFile.getAbsolutePath());
+
+
+                SpringBootJarIndexer indexer = new SpringBootJarIndexer(jarFile);
+                IndexOfFiles index = indexer.indexJar(cmd.recursive);
+        
+                SpringBootIndexReporter reporter = new SpringBootIndexReporter();
+                String report = reporter.generateReport(index, cmd.reportOptions);
+        
+                BufferedWriter writer = new BufferedWriter(new FileWriter(indexFile));
+                writer.write(report);
+                writer.close();
+                
+                System.out.println("Wrote index file as "+cmd.outputPath);
+            } else {
+                System.err.println("Operation "+cmd.operation+" is not implemented.");
+            }
+        }
+    }
+
+    protected static void usage() {
+        System.out.println("Spring Boot Jar Inspector");
+        System.out.println("Usage:");
+        System.out.println("  java -jar springboot-cli.jar MODE OPERATION [operation specific args]");
+        System.out.println("    MODE: 'inspector' for running operations on a single Spring Boot jar; 'comparator' when running operations with multiple Spring Boot jars"); 
+        System.out.println("    OPERATION: a keyword that activates a particular operation; operations are documented below");
+        System.out.println("\n");
+        
+        System.out.println("INSPECTOR OPERATIONS:");
+        System.out.println("\n");
+        System.out.println(" index: generates an index of files within the Spring Boot jar.");
+        System.out.println("   java -jar springboot-cli.jar inspect index SPRING-BOOT-JAR-PATH INDEX-REPORT-PATH [--recursive] [--report REPORT-OPTIONS]");
+        System.out.println("     SPRING-BOOT-JAR-PATH: path to your Spring Boot executable jar file; it must exist");
+        System.out.println("     INDEX-REPORT-PATH: path to write the report from this tool; it must not already exist");
+        System.out.println("     --recursive: if present, inspector will also index the contents of the nested jars found inside the Spring Boot jar");
+        System.out.println("     REPORT-OPTIONS: optional list of modifiers to the reporting engine; see docs for details");
+    }
+
+    protected static Command parseArgs(String[] args) {
+        // TODO this is pretty awkward but keeping it simple for now
+        
+        Command cmd = new Command();
+        cmd.mode = args[0];
+        cmd.operation = args[1];
+        System.out.println("Mode: "+cmd.mode);
+        System.out.println("Operation: "+cmd.operation);
+        
+        int optionalArgIndex = 2;
+        if ("inspector".equals(cmd.mode)) {
+            if ("index".equals(cmd.operation)) {
+                cmd.jarFilepath = args[2];
+                cmd.outputPath = args[3];
+                System.out.println("Spring Boot Jar: "+cmd.jarFilepath);
+                System.out.println("Index output file: "+cmd.outputPath);
+                optionalArgIndex = 4;
+            }
+        }
+        parseOptionalArgs(args, optionalArgIndex, cmd);
+        return cmd;
+    }
+    
+    protected static void parseOptionalArgs(String[] args, int index, Command cmd) {
+        for (int i = index; i<args.length; i++) {
+            if ("--recursive".equals(args[i])) {
+                cmd.recursive = true;
+                System.out.println("Recursive: true");
+            } else if ("--report".equals(args[i])) {
+                cmd.reportOptions = args[i+1];
+                i++;
+                System.out.println("Report options: "+cmd.reportOptions);
+            } else {
+                System.err.println("Unrecognized parameter "+args[i]+ ". Ignoring.");
+            }
+        }
+        
+    }
+    
+    public static class Command {
+        // General args
+        public String mode;
+        public String operation;
+        public String jarFilepath;
+        public String outputPath;
+        
+        // inspector:index args
+        public boolean recursive = false;
+        public String reportOptions = null;
+    }
+
+}

--- a/springboot/src/main/java/com/salesforce/rulesspring/index/IndexFileType.java
+++ b/springboot/src/main/java/com/salesforce/rulesspring/index/IndexFileType.java
@@ -1,0 +1,7 @@
+package com.salesforce.rulesspring.index;
+
+public enum IndexFileType {
+    LIBRARY, // jar file
+    CLASS, // .class file
+    RESOURCE // anything else
+}

--- a/springboot/src/main/java/com/salesforce/rulesspring/index/IndexOfFiles.java
+++ b/springboot/src/main/java/com/salesforce/rulesspring/index/IndexOfFiles.java
@@ -1,0 +1,75 @@
+package com.salesforce.rulesspring.index;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The index generated from inspecting a jar file.
+ */
+public class IndexOfFiles {
+    
+    // We have two types of index objects:
+    // 1. index of the files directly inside the spring boot executable jar
+    // 2. index of the contents of a jar file inside the spring boot executable jar (aka nested jar)
+    protected boolean isNestedJarIndex = false;
+
+    // either the path on disk to the executable jar (if this is an index of a spring boot jar),
+    // or the relative path of the nested jar file inside the spring boot jar file
+    protected String jarPath;
+    
+    // if this is an index of a jar file inside the executable jar (nested jar) this will point to the 
+    // spring boot exectuable jar index
+    protected IndexedFile parentIndex;
+    
+    // The lists of found files:
+    protected List<IndexedFile> libraries = new ArrayList<>();
+    protected List<IndexedFile> classes = new ArrayList<>();
+    protected List<IndexedFile> resources = new ArrayList<>();
+    
+    public IndexOfFiles(String jarPath) {
+        this.jarPath = jarPath;
+    }
+
+    public IndexOfFiles(IndexedFile parentIndex, String jarPath) {
+        this.parentIndex = parentIndex;
+        this.isNestedJarIndex = true;
+        this.jarPath = jarPath;
+    }
+
+    public void addIndexEntry(IndexedFile indexEntry) {
+        switch (indexEntry.type) {
+        case LIBRARY:
+            libraries.add(indexEntry);
+            break;
+        case CLASS:
+            classes.add(indexEntry);
+            break;
+        case RESOURCE:
+            resources.add(indexEntry);
+            break;
+        default:
+            throw new IllegalStateException("Somebody added a new Index entry type, but forgot to build an index collection for it.");
+        }
+        
+    }
+
+    public String getJarPath() {
+        return jarPath;
+    }
+    
+    public IndexedFile getParentIndex() {
+        return parentIndex;
+    }
+    
+    public List<IndexedFile> getLibraries() {
+        return libraries;
+    }
+
+    public List<IndexedFile> getClasses() {
+        return classes;
+    }
+
+    public List<IndexedFile> getResources() {
+        return resources;
+    }
+}

--- a/springboot/src/main/java/com/salesforce/rulesspring/index/IndexedFile.java
+++ b/springboot/src/main/java/com/salesforce/rulesspring/index/IndexedFile.java
@@ -1,0 +1,74 @@
+package com.salesforce.rulesspring.index;
+
+import java.nio.file.attribute.FileTime;
+import java.util.Comparator;
+import java.util.zip.ZipEntry;
+
+/**
+ * Represents a file found inside of a jar file.
+ */
+public class IndexedFile {
+    // library (jar), class, or resource file
+    protected IndexFileType type;
+    
+    // full path inside of the jar file
+    protected String fullPath;
+    
+    // the filename, i.e. the last path element of the fullPath
+    protected String filename;
+    
+    protected long sizeInBytes = 0;
+    protected long createdTimeMillis = 0;
+    protected long modifiedTimeMillis = 0;
+
+    // if this index entry is for a file found in a nested jar inside of an outer jar, parentLibrary will
+    // point to the index of the parent jar
+    protected IndexedFile parentLibrary = null; 
+
+    static IndexedFile parseZipEntry(IndexedFile parentLibrary, ZipEntry zipEntry) {
+        IndexedFile indexEntry = new IndexedFile();
+        indexEntry.fullPath = zipEntry.getName();
+        indexEntry.filename = indexEntry.fullPath;
+        
+        String fp = indexEntry.fullPath;
+        if (fp.contains("/")) {
+            int lastSlash = fp.lastIndexOf("/");
+            indexEntry.filename = fp.substring(lastSlash+1);
+        }
+        
+        if (fp.contains("BOOT-INF/lib") && fp.endsWith(".jar")) {
+            indexEntry.type = IndexFileType.LIBRARY;
+        }
+        else if (fp.endsWith(".class")) {
+            indexEntry.type = IndexFileType.CLASS;
+        } else { 
+            indexEntry.type = IndexFileType.RESOURCE;
+        }
+        
+        indexEntry.sizeInBytes = zipEntry.getSize();
+        FileTime fTime = zipEntry.getCreationTime();
+        if (fTime != null) {
+            indexEntry.createdTimeMillis = fTime.toMillis();
+        }
+        fTime = zipEntry.getLastModifiedTime();
+        if (fTime != null) {
+            indexEntry.modifiedTimeMillis = fTime.toMillis();
+        }
+
+        return indexEntry;
+    }
+    
+    public static class FullPathComparator implements Comparator<IndexedFile> {
+        @Override
+        public int compare(IndexedFile e1, IndexedFile e2) {
+            return e1.fullPath.compareTo(e2.fullPath); 
+        }
+    }
+
+    public static class FilenameComparator implements Comparator<IndexedFile> {
+        @Override
+        public int compare(IndexedFile e1, IndexedFile e2) {
+            return e1.filename.compareTo(e2.filename); 
+        }
+    }
+}

--- a/springboot/src/main/java/com/salesforce/rulesspring/index/SpringBootIndexReporter.java
+++ b/springboot/src/main/java/com/salesforce/rulesspring/index/SpringBootIndexReporter.java
@@ -1,0 +1,110 @@
+package com.salesforce.rulesspring.index;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Generates the text report with the results of an indexing operation.
+ * This class is pretty simple, so the code serves as the documentation.
+ * <p>
+ * To see what options are implemented, see parseOptions() below.
+ */
+public class SpringBootIndexReporter {
+    
+    protected boolean includeLibs = true;
+    protected boolean includeClasses = true;
+    protected boolean includeResources = true;
+    
+    protected boolean prettyHeadings = true;
+    
+    protected boolean writeFullPaths = false;
+    protected boolean writeFileSize = false;
+    protected boolean writeCreatedTime = false;
+    protected boolean writeModifiedTime = false;
+    
+    protected boolean sortOnFullPaths = false;
+    
+    public SpringBootIndexReporter() {
+        
+    }
+
+    public String generateReport(IndexOfFiles index) {
+        return this.generateReport(index, null);
+    }
+
+    public String generateReport(IndexOfFiles index, String options) {
+        StringBuffer result = new StringBuffer();
+        parseOptions(options);
+        
+        Comparator<IndexedFile> sortOrder = new IndexedFile.FilenameComparator();
+        if (sortOnFullPaths) {
+            sortOrder = new IndexedFile.FullPathComparator();
+        }
+        
+        if (prettyHeadings) {
+            result.append("Jar File: ");
+            result.append(index.getJarPath());
+            result.append("\n");
+        }
+        
+        if (includeLibs) {
+            index.libraries.sort(sortOrder);
+            processList(index.libraries, "Libraries", result);
+        }
+
+        if (includeClasses) {
+            index.classes.sort(sortOrder);
+            processList(index.classes, "Classes", result);
+        }
+
+        if (includeResources) {
+            index.resources.sort(sortOrder);
+            processList(index.resources, "Resources", result);
+        }
+
+        return result.toString();
+    }
+    
+    protected void parseOptions(String options) {
+        if (options == null) {
+            return;
+        }
+        includeLibs = options.contains("L"); // write the list of .jar files found
+        includeClasses = options.contains("C"); // write the list of  .class files found
+        includeResources = options.contains("R"); // write the list of other files found
+        prettyHeadings = options.contains("H"); // write pretty headings into the output
+        writeFullPaths = options.contains("F"); // write full paths of each entry
+        writeFileSize = options.contains("Z"); // write the file size of each file
+        writeCreatedTime = options.contains("B"); // write the created time of each file
+        writeModifiedTime = options.contains("M"); // write the modified time of each file
+        sortOnFullPaths = options.contains("S"); // when sorting, sort on the path and not the filename
+    }
+    
+    protected void processList(List<IndexedFile> list, String headingLabel, StringBuffer result) {
+        if (prettyHeadings) {
+            result.append("\n\n");
+            result.append(headingLabel);
+            result.append("\n---------------\n");
+        }
+        for (IndexedFile lib : list) {
+            if (writeFullPaths) {
+                result.append(lib.fullPath);
+            } else {
+                result.append(lib.filename);
+            }
+            if (writeFileSize) {
+                result.append("  size=");
+                result.append(""+lib.sizeInBytes);
+            }
+            if (writeCreatedTime) {
+                result.append("  created=");
+                result.append(""+lib.createdTimeMillis);
+            }
+            if (writeModifiedTime) {
+                result.append("  modified=");
+                result.append(""+lib.modifiedTimeMillis);
+            }
+            result.append("\n");
+        }
+    }
+}

--- a/springboot/src/main/java/com/salesforce/rulesspring/index/SpringBootJarIndexer.java
+++ b/springboot/src/main/java/com/salesforce/rulesspring/index/SpringBootJarIndexer.java
@@ -1,0 +1,68 @@
+package com.salesforce.rulesspring.index;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * Produces an index from the contents of a Spring Boot jar.
+ */
+public class SpringBootJarIndexer {
+
+    protected File bootJarFile;
+    
+    public SpringBootJarIndexer(File jarFile) {
+        this.bootJarFile = jarFile;
+    }
+
+    /**
+     * Index the contents of the Spring Boot jar.
+     * 
+     * @param recursive if true, it will produce child indices of each nested jar inside the Spring Boot executable jar.
+     */
+    public IndexOfFiles indexJar(boolean recursive) throws IOException {
+        IndexOfFiles index = new IndexOfFiles(bootJarFile.getAbsolutePath());
+        try (ZipFile zipFile = new ZipFile(this.bootJarFile)) {
+            
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            for (ZipEntry entry : Collections.list(entries)) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                IndexedFile indexEntry = IndexedFile.parseZipEntry(null, entry);
+                index.addIndexEntry(indexEntry);
+                
+                if (recursive && indexEntry.type.equals(IndexFileType.LIBRARY)) {
+                    // TODO do the nested indexing
+                    indexJar(indexEntry, entry);
+                }
+            }
+        } 
+        return index;
+    }
+
+    /**
+     * Create a child index for a nested jar.
+     */
+    protected IndexOfFiles indexJar(IndexedFile parentLibrary, ZipEntry nestedJar) throws IOException {
+        
+        // TODO this needs to be reworked to open the jar from the ZipEntry
+        
+        IndexOfFiles index = new IndexOfFiles(bootJarFile.getAbsolutePath());
+        try (ZipFile zipFile = new ZipFile(this.bootJarFile)) {
+            
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            for (ZipEntry entry : Collections.list(entries)) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                IndexedFile indexEntry = IndexedFile.parseZipEntry(parentLibrary, entry);
+                index.addIndexEntry(indexEntry);
+            }
+        } 
+        return index;
+    }
+}

--- a/springboot/src/test/java/com/salesforce/rulesspring/index/SpringBootJarIndexerTest.java
+++ b/springboot/src/test/java/com/salesforce/rulesspring/index/SpringBootJarIndexerTest.java
@@ -1,0 +1,5 @@
+package com.salesforce.rulesspring.index;
+
+public class SpringBootJarIndexerTest {
+
+}


### PR DESCRIPTION
While working on an issue today, wanted a better way to slice and dice the contents of the problematic Spring Boot app. Ended up writing a simple indexer CLI. This code locastion will serve eventually as the location of the reimplementation of the _springboot_ rule in Java (see #3) . For now it is just a single operation CLI.