### PR TITLE
propagate visibility for springboot jar

### DIFF
--- a/springboot/springboot.bzl
+++ b/springboot/springboot.bzl
@@ -434,6 +434,7 @@ def springboot(
         testonly = testonly,
         outs = [_get_springboot_jar_file_name(name)],
         toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],  # so that JAVABASE is computed
+        visibility = visibility,
     )
 
     # SUBRULE 3B: GENERATE THE ENV VARIABLES USED BY THE BAZELRUN LAUNCHER SCRIPT


### PR DESCRIPTION
The scenario where a docker_image target is in a different package from the springboot target currently doesn't work due to the springboot jar not having any visibility propagated. E.g. the following does not work:

- springboot target defined in //projects/services/a/service
- docker_image target defined in //projects/services/a

With this change, the above works.