### PR TITLE
provide mechanism to not include git.properties file in resulting jar

### DIFF
--- a/springboot/springboot.bzl
+++ b/springboot/springboot.bzl
@@ -249,6 +249,7 @@ def springboot(
         deps_use_starlark_order = None,
         dupeclassescheck_enable = None,
         dupeclassescheck_ignorelist = None,
+        include_git_properties_file=True,
         bazelrun_script = None,
         bazelrun_jvm_flags = None,
         bazelrun_data = None,
@@ -295,6 +296,7 @@ def springboot(
         once, but with a different hash. This indicates that your dependency tree has conflicting libraries.
       dupeclassescheck_ignorelist: Optional. When using the duplicate class check, this attribute provides a file
         that contains a list of libraries excluded from the analysis. Ex: *dupeclass_libs.txt*
+      include_git_properties_file: If *True*, will include a git.properties file in the resulting jar.
       bazelrun_script: Optional. When launching the application using 'bazel run', a default launcher script is used.
         This attribute can be used to provide a customized launcher script. Ex: *my_custom_script.sh*
       bazelrun_jvm_flags: Optional. When launching the application using 'bazel run', an optional set of JVM flags
@@ -406,12 +408,13 @@ def springboot(
     #    param3: jdk path for running java tools e.g. jar; $(JAVABASE)
     #    param4: compiled application jar name
     #    param5: use build file deps order [True|False]
-    #    param6: executable jar output filename to write to
-    #    param7: compiled application jar
-    #    param8: manifest file
-    #    param9: git.properties file
-    #    param10: classpath_index file
-    #    param11-N: upstream transitive dependency jar(s)
+    #    param6: include git.properties file in resulting jar
+    #    param7: executable jar output filename to write to
+    #    param8: compiled application jar
+    #    param9: manifest file
+    #    param10: git.properties file
+    #    param11: classpath_index file
+    #    param12-N: upstream transitive dependency jar(s)
     native.genrule(
         name = genjar_rule,
         srcs = [
@@ -425,7 +428,7 @@ def springboot(
         ],
         cmd = "$(location @rules_spring//springboot:springboot_pkg.sh) " +
               "$(location @bazel_tools//tools/jdk:singlejar) " + boot_app_class +
-              " $(JAVABASE) " + name + " " + str(deps_use_starlark_order) + " $@ $(SRCS)",
+              " $(JAVABASE) " + name + " " + str(deps_use_starlark_order) + " " + str(include_git_properties_file) + " $@ $(SRCS)",
         tools = [
             "@rules_spring//springboot:springboot_pkg.sh",
             "@bazel_tools//tools/jdk:singlejar",

--- a/springboot/springboot_doc.md
+++ b/springboot/springboot_doc.md
@@ -5,9 +5,10 @@
 ## springboot
 
 <pre>
-springboot(<a href="#springboot-name">name</a>, <a href="#springboot-java_library">java_library</a>, <a href="#springboot-boot_app_class">boot_app_class</a>, <a href="#springboot-deps">deps</a>, <a href="#springboot-deps_exclude">deps_exclude</a>, <a href="#springboot-deps_index_file">deps_index_file</a>,
-           <a href="#springboot-deps_use_starlark_order">deps_use_starlark_order</a>, <a href="#springboot-dupeclassescheck_enable">dupeclassescheck_enable</a>, <a href="#springboot-dupeclassescheck_ignorelist">dupeclassescheck_ignorelist</a>,
-           <a href="#springboot-bazelrun_script">bazelrun_script</a>, <a href="#springboot-bazelrun_jvm_flags">bazelrun_jvm_flags</a>, <a href="#springboot-bazelrun_data">bazelrun_data</a>, <a href="#springboot-bazelrun_background">bazelrun_background</a>, <a href="#springboot-tags">tags</a>, <a href="#springboot-testonly">testonly</a>, <a href="#springboot-visibility">visibility</a>,
+springboot(<a href="#springboot-name">name</a>, <a href="#springboot-java_library">java_library</a>, <a href="#springboot-boot_app_class">boot_app_class</a>, <a href="#springboot-deps">deps</a>, <a href="#springboot-deps_exclude">deps_exclude</a>, <a href="#springboot-deps_exclude_paths">deps_exclude_paths</a>,
+           <a href="#springboot-deps_index_file">deps_index_file</a>, <a href="#springboot-deps_use_starlark_order">deps_use_starlark_order</a>, <a href="#springboot-dupeclassescheck_enable">dupeclassescheck_enable</a>,
+           <a href="#springboot-dupeclassescheck_ignorelist">dupeclassescheck_ignorelist</a>, <a href="#springboot-include_git_properties_file">include_git_properties_file</a>, <a href="#springboot-bazelrun_script">bazelrun_script</a>,
+           <a href="#springboot-bazelrun_jvm_flags">bazelrun_jvm_flags</a>, <a href="#springboot-bazelrun_data">bazelrun_data</a>, <a href="#springboot-bazelrun_background">bazelrun_background</a>, <a href="#springboot-addins">addins</a>, <a href="#springboot-tags">tags</a>, <a href="#springboot-testonly">testonly</a>, <a href="#springboot-visibility">visibility</a>,
            <a href="#springboot-exclude">exclude</a>, <a href="#springboot-classpath_index">classpath_index</a>, <a href="#springboot-use_build_dependency_order">use_build_dependency_order</a>, <a href="#springboot-fail_on_duplicate_classes">fail_on_duplicate_classes</a>,
            <a href="#springboot-duplicate_class_allowlist">duplicate_class_allowlist</a>, <a href="#springboot-jvm_flags">jvm_flags</a>, <a href="#springboot-data">data</a>)
 </pre>
@@ -26,19 +27,20 @@ Note that the rule README has more detailed usage instructions for each attribut
 | java_library |  **Required**. The built jar, identified by the name of the java_library rule, that contains the   Spring Boot application.   |  none |
 | boot_app_class |  **Required**. The fully qualified name of the class annotated with @SpringBootApplication.   Ex: *com.sample.SampleMain*   |  none |
 | deps |  Optional. An additional set of Java dependencies to add to the executable.   Normally all dependencies are set on the *java_library*.   |  <code>None</code> |
-| deps_exclude |  Optional. A list of jar labels that will be omitted from the final packaging step. This is a manual option for eliminating a problematic dependency that cannot be eliminated upstream.   Ex: *["@maven//:commons_cli_commons_cli"]*.   |  <code>None</code> |
-| deps_exclude_paths |  Optional. This attribute provides a list of partial paths that will be omitted from the final packaging step if the string is contained within the dep filename. This is a more raw method than deps_exclude for eliminating a problematic dependency/file that cannot be eliminated upstream. Ex: [*jackson-databind-*].   |  <code>None</code> |
+| deps_exclude |  Optional. This attribute provides a list of partial paths that will be omitted   from the final packaging step if the string is contained within the dep filename. This is a more raw method   than deps_exclude for eliminating a problematic dependency/file that cannot be eliminated upstream.   Ex: [*jackson-databind-*].   |  <code>None</code> |
+| deps_exclude_paths |  <p align="center"> - </p>   |  <code>None</code> |
 | deps_index_file |  Optional. Uses Spring Boot's   [classpath index feature](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-executable-jar-format.html#executable-jar-war-index-files-classpath)   to define classpath order. This feature is not commonly used, as the application must be extracted from the jar   file for it to work. Ex: *my_classpath_index.idx*   |  <code>None</code> |
-| deps_use_starlark_order |  When running the Spring Boot application from the executable jar file, setting this attribute to   *True* will use the classpath order as expressed by the order of deps in the BUILD file. Otherwise it is random order.   |  <code>True</code> |
-| dupeclassescheck_enable |  If *True*, will analyze the list of dependencies looking for any class that appears more than   once, but with a different hash. This indicates that your dependency tree has conflicting libraries.   |  <code>False</code> |
-| dupeclassescheck_ignorelist |  Optional. When using the duplicate class check, this attribute can provide a file   that contains a list of libraries excluded from the analysis. Ex: *dupeclass_libs.txt*   |  <code>None</code> |
+| deps_use_starlark_order |  When running the Spring Boot application from the executable jar file, setting this attribute to   *True* will use the classpath order as expressed by the order of deps in the BUILD file. Otherwise it is random order.   |  <code>None</code> |
+| dupeclassescheck_enable |  If *True*, will analyze the list of dependencies looking for any class that appears more than   once, but with a different hash. This indicates that your dependency tree has conflicting libraries.   |  <code>None</code> |
+| dupeclassescheck_ignorelist |  Optional. When using the duplicate class check, this attribute provides a file   that contains a list of libraries excluded from the analysis. Ex: *dupeclass_libs.txt*   |  <code>None</code> |
+| include_git_properties_file |  If *True*, will include a git.properties file in the resulting jar.   |  <code>True</code> |
 | bazelrun_script |  Optional. When launching the application using 'bazel run', a default launcher script is used.   This attribute can be used to provide a customized launcher script. Ex: *my_custom_script.sh*   |  <code>None</code> |
 | bazelrun_jvm_flags |  Optional. When launching the application using 'bazel run', an optional set of JVM flags   to pass to the JVM at startup. Ex: *-Dcustomprop=gold -DcustomProp2=silver*   |  <code>None</code> |
 | bazelrun_data |  Uncommon option to add data files to runfiles. Behaves like the *data* attribute defined for *java_binary*.   |  <code>None</code> |
 | bazelrun_background |  Optional. If True, the *bazel run* launcher will not block. The run command will return and process will remain running.   |  <code>False</code> |
-| addins | Uncommon option to add additional files to the root of the springboot jar. For example a license file. Pass an array of files from the package. | <code>None</code> |
+| addins |  Uncommon option to add additional files to the root of the springboot jar. For example a license file. Pass an array of files from the package.   |  <code>[]</code> |
 | tags |  Optional. Bazel standard attribute.   |  <code>[]</code> |
-| testonly |  Optional. Bazel standard attribute.   |  <code>False</code> |
+| testonly |  Optional. Bazel standard attribute. Defaults to False.   |  <code>False</code> |
 | visibility |  Optional. Bazel standard attribute.   |  <code>None</code> |
 | exclude |  Deprecated synonym of *deps_exclude*   |  <code>[]</code> |
 | classpath_index |  Deprecated synonym of *deps_index_file*   |  <code>"@rules_spring//springboot:empty.txt"</code> |
@@ -47,3 +49,5 @@ Note that the rule README has more detailed usage instructions for each attribut
 | duplicate_class_allowlist |  Deprecated synonym of *dupeclassescheck_ignorelist*   |  <code>None</code> |
 | jvm_flags |  Deprecated synonym of *bazelrun_jvm_flags*   |  <code>""</code> |
 | data |  Deprecated synonym of *bazelrun_data*   |  <code>[]</code> |
+
+

--- a/springboot/springboot_pkg.sh
+++ b/springboot/springboot_pkg.sh
@@ -28,7 +28,7 @@ include_git_properties_file=$6
 outputjar=$7
 appjar=$8
 manifest=$9
-gitpropsfile=$10
+gitpropsfile=${10}
 deps_index_file=${11}
 first_addin_arg=12
 
@@ -94,6 +94,7 @@ echo "  appjar_name     $appjar_name (unused, is the appjar filename without the
 echo "  manifest        $manifest    (the location of the generated manifest.MF file)" >> $debugfile
 echo "  deps_index_file $deps_index_file (the location of the classpath index file - optional)" >> $debugfile
 echo "  deplibs         (list of upstream transitive dependencies, these will be incorporated into the jar file in BOOT-INF/lib )" >> $debugfile
+echo "  gitpropsfile    $gitpropsfile (the location of the generated git.properties file)" >> $debugfile
 echo "*************************************************************************************" >> $debugfile
 
 # compute path to jar utility
@@ -233,13 +234,10 @@ echo "DEBUG: finished copying transitives into BOOT-INF/lib, elapsed time (secon
 # Inject the Git properties into a properties file in the jar
 # (the -f is needed when remote caching is used, as cached files come down as r-x and
 #  if you rerun the build it needs to overwrite)
-echo $include_git_properties_file
-if [[ $include_git_properties_file = true ]]; then
+if [[ "$include_git_properties_file" == true ]]; then
   echo "DEBUG: adding git.properties" >> $debugfile
   cat $ruledir/$gitpropsfile >> $debugfile
-  echo "DEBUG: kaaa" >> $debugfile
   cp -f $ruledir/$gitpropsfile $working_dir/BOOT-INF/classes
-  echo "DEBUG: baaa" >> $debugfile
 fi
 
 # Inject the classpath index (unless it is the default empty.txt file). Requires Spring Boot version 2.3+

--- a/springboot/springboot_pkg.sh
+++ b/springboot/springboot_pkg.sh
@@ -24,17 +24,25 @@ mainclass=$2
 javabase=$3
 appjar_name=$4
 deps_starlark_order=$5
-outputjar=$6
-appjar=$7
-manifest=$8
-gitpropsfile=$9
-deps_index_file=${10}
-first_addin_arg=11
+include_git_properties_file=$6
+outputjar=$7
+appjar=$8
+manifest=$9
+gitpropsfile=$10
+deps_index_file=${11}
+first_addin_arg=12
 
+# converting starlark booleans to bash booleans
 if [ $deps_starlark_order = "True" ]; then
   deps_starlark_order=true
 else
   deps_starlark_order=false
+fi
+
+if [ $include_git_properties_file = "True" ]; then
+  include_git_properties_file=true
+else
+  include_git_properties_file=false
 fi
 
 # package name (not guaranteed to be globally unique)
@@ -225,9 +233,14 @@ echo "DEBUG: finished copying transitives into BOOT-INF/lib, elapsed time (secon
 # Inject the Git properties into a properties file in the jar
 # (the -f is needed when remote caching is used, as cached files come down as r-x and
 #  if you rerun the build it needs to overwrite)
-echo "DEBUG: adding git.properties" >> $debugfile
-cat $ruledir/$gitpropsfile >> $debugfile
-cp -f $ruledir/$gitpropsfile $working_dir/BOOT-INF/classes
+echo $include_git_properties_file
+if [[ $include_git_properties_file = true ]]; then
+  echo "DEBUG: adding git.properties" >> $debugfile
+  cat $ruledir/$gitpropsfile >> $debugfile
+  echo "DEBUG: kaaa" >> $debugfile
+  cp -f $ruledir/$gitpropsfile $working_dir/BOOT-INF/classes
+  echo "DEBUG: baaa" >> $debugfile
+fi
 
 # Inject the classpath index (unless it is the default empty.txt file). Requires Spring Boot version 2.3+
 # https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-executable-jar-format.html#executable-jar-war-index-files-classpath


### PR DESCRIPTION
https://github.com/salesforce/rules_spring/issues/163

## Motivation?

Sometimes people don't want to include the git.properties in the jar they will deploy (security etc).

## How?

Providing mechanism to not include git.properties file in the resulting jar e.g.
```
springboot(
    name = "abc",
    boot_app_class = "x.y.z",
    include_git_properties_file = False,
    java_library = ":abc",
)
```

The above target results in the following behaviour:

```
jar tf bazel-bin/projects/something/abc.jar | grep git.properties

<whole lot of nothing>
```

Also generated new Stardocs (this is cool, never saw it before).