### PR TITLE
add bazelrun_java_toolchain attribute to launch service with the java toolchain JVM

### DIFF
--- a/springboot/default_bazelrun_script.sh
+++ b/springboot/default_bazelrun_script.sh
@@ -22,11 +22,23 @@ set -e
 # versions of Bazel because they are documented:
 #  https://docs.bazel.build/versions/master/user-manual.html#run
 
-# soon we will use one of the jdk locations already known to Bazel, see Issue #16
-if [ -z ${JAVA_HOME} ]; then
-  java_cmd="$(which java)"
-else
+# Picking the Java VM to run is a bit of an ordeal.
+# 1. honor any environmental variable BAZEL_RUN_JAVA (optional)
+# 2. use the java executable from the java toolchain passed into the rule (optional)
+# 3. use non-hermetic JAVA_HOME
+# 4. as a last resort, use 'which java'
+if [ -d "${BAZEL_RUN_JAVA}" ]; then
+  echo "Selected the JVM using the BAZEL_RUN_JAVA environment variable."
+  java_cmd=$BAZEL_RUN_JAVA
+elif [ -f "$JAVA_TOOLCHAIN" ]; then
+  echo "Selected the JVM using the bazelrun_java_toolchain attribute on the springboot rule."
+  java_cmd=$JAVA_TOOLCHAIN
+elif [ -d "${JAVA_HOME}" ]; then
+  echo "Selected the JVM using the JAVA_HOME environment variable."
   java_cmd="${JAVA_HOME}/bin/java"
+else
+  echo "Selected the JVM by executing 'which java'"
+  java_cmd="$(which java)"
 fi
 
 if [ -z "${java_cmd}" ]; then

--- a/springboot/springboot_doc.md
+++ b/springboot/springboot_doc.md
@@ -34,6 +34,7 @@ Note that the rule README has more detailed usage instructions for each attribut
 | dupeclassescheck_enable |  If *True*, will analyze the list of dependencies looking for any class that appears more than   once, but with a different hash. This indicates that your dependency tree has conflicting libraries.   |  <code>None</code> |
 | dupeclassescheck_ignorelist |  Optional. When using the duplicate class check, this attribute provides a file   that contains a list of libraries excluded from the analysis. Ex: *dupeclass_libs.txt*   |  <code>None</code> |
 | include_git_properties_file |  If *True*, will include a git.properties file in the resulting jar.   |  <code>True</code> |
+| bazelrun_java_toolchain |  Optional. When launching the application using 'bazel run', this attribute can identify the label of the Java toolchain used to launch the JVM. Ex: *//tools/jdk:my_default_toolchain*. See *default_java_toolchain* in the Bazel documentation.  |  <code>None</code> |
 | bazelrun_script |  Optional. When launching the application using 'bazel run', a default launcher script is used.   This attribute can be used to provide a customized launcher script. Ex: *my_custom_script.sh*   |  <code>None</code> |
 | bazelrun_jvm_flags |  Optional. When launching the application using 'bazel run', an optional set of JVM flags   to pass to the JVM at startup. Ex: *-Dcustomprop=gold -DcustomProp2=silver*   |  <code>None</code> |
 | bazelrun_data |  Uncommon option to add data files to runfiles. Behaves like the *data* attribute defined for *java_binary*.   |  <code>None</code> |
@@ -49,5 +50,3 @@ Note that the rule README has more detailed usage instructions for each attribut
 | duplicate_class_allowlist |  Deprecated synonym of *dupeclassescheck_ignorelist*   |  <code>None</code> |
 | jvm_flags |  Deprecated synonym of *bazelrun_jvm_flags*   |  <code>""</code> |
 | data |  Deprecated synonym of *bazelrun_data*   |  <code>[]</code> |
-
-


### PR DESCRIPTION
Solves #16 effectively. It allows the caller to pass in the label to a java toolchain into the springboot macro. Then, when the user launches the service with bazel run, the JVM will be launched from the toolchain.

Also added support for BAZEL_RUN_JAVA environment variable that will be used before any other options.