### PR TITLE
improve default behavior of bazel run jvm

### DIFF
--- a/springboot/bazelrun.md
+++ b/springboot/bazelrun.md
@@ -10,6 +10,36 @@ But you may wish to customize the launch.
 The *springboot* rule supports several features for customization.
 Note that these features do **not** apply when running the application directly using ```java -jar [file]```.
 
+### Launcher JVM
+
+By default, the service will be started using the JVM from the current Java toolchain in your
+  Bazel workspace - `@bazel_tools//tools/jdk:current_java_toolchain`
+See the [Bazel Java docs](https://bazel.build/docs/bazel-and-java) on how toolchains are defined.
+However, there are multiple ways to override this.
+
+First, you can set the `BAZEL_RUN_JAVA` environment variable to the Java executable of your choice.
+This works well for local overrides, when you want to test new Java distributions.
+This variable, when set, takes priority over the toolchain configurations.
+
+```
+export BAZEL_RUN_JAVA=/opt/my_jdk/bin/java
+```
+
+Second, you can use the `bazelrun_java_toolchain` to pass the label to a Java toolchain
+  defined in your Bazel workspace.
+The bazel run script will use the JVM from the toolchain.
+
+```
+springboot(
+   ...
+   bazelrun_java_toolchain = "//tools/jdk:my_default_toolchain",  
+)
+```
+
+Finally, you can provide a custom launcher script (see below) that can tailor JVM selection as needed.
+This is the most flexible option, but it may cause compatibility issues with newer versions of rules_spring.
+
+
 ### Java Startup Options
 
 You may wish to customize the bazel run launcher with JVM options.

--- a/springboot/default_bazelrun_script.sh
+++ b/springboot/default_bazelrun_script.sh
@@ -22,16 +22,17 @@ set -e
 # versions of Bazel because they are documented:
 #  https://docs.bazel.build/versions/master/user-manual.html#run
 
-# Picking the Java VM to run is a bit of an ordeal.
-# 1. honor any environmental variable BAZEL_RUN_JAVA (optional)
-# 2. use the java executable from the java toolchain passed into the rule (optional)
-# 3. use non-hermetic JAVA_HOME
-# 4. as a last resort, use 'which java'
-if [ -d "${BAZEL_RUN_JAVA}" ]; then
+# Picking the Java VM to run is a bit of an ordeal. We now default to using the
+#   JVM from @bazel_tools//tools/jdk:current_java_toolchain. But you can override that.
+#  1. honor any environmental variable BAZEL_RUN_JAVA (optional)
+#  2. use the java executable from the java toolchain passed into the rule (default)
+#  3. use non-hermetic JAVA_HOME (dead code, we no longer allow this)
+#  4. as a last resort, use 'which java' (dead code, we no longer allow this)
+if [ -f "${BAZEL_RUN_JAVA}" ]; then
   echo "Selected the JVM using the BAZEL_RUN_JAVA environment variable."
   java_cmd=$BAZEL_RUN_JAVA
 elif [ -f "$JAVA_TOOLCHAIN" ]; then
-  echo "Selected the JVM using the bazelrun_java_toolchain attribute on the springboot rule."
+  echo "Selected the JVM using the Bazel Java toolchain: $JAVA_TOOLCHAIN_NAME"
   java_cmd=$JAVA_TOOLCHAIN
 elif [ -d "${JAVA_HOME}" ]; then
   echo "Selected the JVM using the JAVA_HOME environment variable."
@@ -42,7 +43,7 @@ else
 fi
 
 if [ -z "${java_cmd}" ]; then
-  echo "ERROR: no java found, either set JAVA_HOME or add the java executable to your PATH"
+  echo "ERROR: no java found. See the Bazel Run docs in rules_spring for details."
   exit 1
 fi
 echo "Using Java at ${java_cmd}"

--- a/springboot/springboot.bzl
+++ b/springboot/springboot.bzl
@@ -239,6 +239,7 @@ else
   # it into an absolute path using exec_root
   exec_root=${SCRIPT_DIR%%bazel-out*}
   JAVA_TOOLCHAIN="${exec_root}${JAVA_TOOLCHAIN_RELATIVE}"
+  JAVA_TOOLCHAIN_NAME=%java_toolchain_name_attr%
 fi
 
 # the env variables file is found in SCRIPT_DIR
@@ -277,6 +278,8 @@ def _springboot_rule_impl(ctx):
       java_bin = [f for f in java_runtime.files.to_list() if f.path.endswith("bin/java")][0]
       outer_bazelrun_script_contents = outer_bazelrun_script_contents \
           .replace("%java_toolchain_attr%", java_bin.path)
+      outer_bazelrun_script_contents = outer_bazelrun_script_contents \
+          .replace("%java_toolchain_name_attr%", ctx.attr.bazelrun_java_toolchain.label.name)
     else:
       outer_bazelrun_script_contents = outer_bazelrun_script_contents \
           .replace("%java_toolchain_attr%", "")
@@ -319,6 +322,7 @@ _springboot_rule = rule(
 
         "bazelrun_java_toolchain": attr.label(
             mandatory = False,
+            default = "@bazel_tools//tools/jdk:current_java_toolchain",
             providers = [java_common.JavaToolchainInfo],
         ),
     },


### PR DESCRIPTION
Iterating on the solution for #16 

Now the default is the current workspace toolchain, instead of JAVA_HOME.