### PR TITLE
Add root classloader support for custom classes

### DIFF
--- a/examples/demoapp/BUILD
+++ b/examples/demoapp/BUILD
@@ -42,6 +42,11 @@ java_library(
     deps = springboot_deps + lib_deps,
 )
 
+java_library(
+    name = "rootclassloader_lib",
+    srcs = glob(["src_root/main/java/**/*.java"]),
+)
+
 test_deps = [
     "@maven//:junit_junit",
     "@maven//:org_hamcrest_hamcrest_core",
@@ -61,7 +66,7 @@ springboot(
 
     # DEPS ARE OPTIONAL HERE
     #  The springboot rule inherits all deps and runtime_deps from the java_library
-    # deps = [],
+    deps = [ ":rootclassloader_lib", ],
 
     # TO TEST THE DUPE CLASSES FEATURE:
     #   There is an intentionally duplicated class in lib1 and lib2. Do this:

--- a/examples/demoapp/src/main/java/com/sample/SampleMain.java
+++ b/examples/demoapp/src/main/java/com/sample/SampleMain.java
@@ -17,7 +17,7 @@ public class SampleMain {
   // this is only a problem if the springboot rule is configured to fail on dupes.
   static private IntentionalDupedClass dupedClass = new IntentionalDupedClass();
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     System.out.println("SampleMain: Launching the sample SpringBoot demo application...");
     StringBuffer sb = new StringBuffer();
     for (String arg : args) {
@@ -28,6 +28,10 @@ public class SampleMain {
     System.out.println("SampleMain:  Command line args: "+sb.toString());
 
     System.out.println("\nSampleMain:  Intentional duped class version: "+dupedClass.hello());
+
+    // test that the root class is available
+    Class.forName("com.sample.SampleRootClass");
+    System.out.println("\nSampleMain:  loaded the root class com.sample.SampleRootClass");
 
     SpringApplication.run(SampleMain.class, args);
   }

--- a/examples/demoapp/src_root/main/java/com/sample/SampleRootClass.java
+++ b/examples/demoapp/src_root/main/java/com/sample/SampleRootClass.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2019-2021, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+*/
+package com.sample;
+
+public class SampleRootClass {
+
+    public String helloMessage;
+
+}

--- a/springboot/springboot_pkg.sh
+++ b/springboot/springboot_pkg.sh
@@ -123,7 +123,7 @@ TMP_working_dir=$base_working_dir/tmp
 mkdir -p $TMP_working_dir
 
 # Addins is the feature to add files to the root of the springboot jar
-# The addins are listed in order as args, until the addin_end.txt file marks the end 
+# The addins are listed in order as args, until the addin_end.txt file marks the end
 i=$first_addin_arg
 while [ "$i" -le "$#" ]; do
   eval "addin=\${$i}"
@@ -170,12 +170,12 @@ while [ "$i" -le "$#" ]; do
   echo "DEBUG: libname: $libname" >> $debugfile
   if [[ $libname == *jar ]]; then
     # we only want to process .jar files as libs
-    if [[ $libname == *spring-boot-loader* ]] || [[ $libname == *spring_boot_loader* ]]; then
+    if [[ $libname == *spring-boot-loader* ]] || [[ $libname == *spring_boot_loader* ]] || [[ $libname == librootclassloader_lib* ]]; then
       # if libname contains the string 'spring-boot-loader' then...
       # the Spring Boot Loader classes are special, they must be extracted at the root level /,
       #   not in BOOT-INF/lib/loader.jar nor BOOT-INF/classes/**/*.class
-      # we only extract org/* since we don't want the toplevel META-INF files
-      $jar_command xf $ruledir/$lib org META-INF/services
+      # we only extract org/* and com/* since we don't want the toplevel META-INF files
+      $jar_command xf $ruledir/$lib com org META-INF/services
     else
       # copy the jar into BOOT-INF/lib, being mindful to prevent name collisions by using subdirectories (see Issue #61)
       # the logic to truncate paths below doesnt need to be perfect, it just hopes to simplify the jar paths so they look better for most cases


### PR DESCRIPTION
This feature is a simple partial solution to #129 . It is for cases where a service needs to inject more classes into the root of the executable jar. This means the classes are written directly into the root of the jar, not in *BOOT-INF/classes* or *BOOT-INF/libs*.

It works by creating a *java_library* target with the special name: **rootclassloader_lib**

```
java_library(
    name = "rootclassloader_lib",
    srcs = glob(["src_root/main/java/**/*.java"]),
)
```

then adding the *java_library* to the deps attribute of the *springboot* rule:

```
springboot(
    name = "demoapp",
    boot_app_class = "com.sample.SampleMain",
    java_library = ":demoapp_lib",

    # inject the root classloaded classes
    deps = [ ":rootclassloader_lib", ],
    ...
```

I am not comfortable making this an official feature since it is a bit hacky, using a naming convention. But adding it in, such that anyone can have a solution for root classes in #129 .

