### PR TITLE
fix python bzlmod issue

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_spring",
-    version = "2.4.1",
+    version = "2.4.2",
     compatibility_level = 1,
     repo_name = "rules_spring",
 )
@@ -10,10 +10,9 @@ bazel_dep(name = "rules_python", version = "0.40.0")
 # For Dupe Class checking support
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
-    # This takes priority over captive python from //tools/python_interpreter unless extra toolchains are specified e.g.
-    # bazel run --extra_toolchains //tools/python_interpreter:captive_python_toolchain <target>
     is_default = True,
     python_version = "3.11",
+    ignore_root_user_error = True, # https://github.com/bazelbuild/rules_python/issues/1169
 )
 
 # For License support


### PR DESCRIPTION
Fixes CI failure due to:

```
Error in fail: The current user is root, please run as non-root when using the hermetic Python interpreter. See https://github.com/bazelbuild/rules_python/pull/713.
```

Solution described by https://github.com/bazelbuild/rules_python/issues/1169 