### PR TITLE
Fix shebang in bazelrun wrapper

### DIFF
--- a/springboot/springboot.bzl
+++ b/springboot/springboot.bzl
@@ -245,8 +245,7 @@ _banneddeps_rule = rule(
 # ***************************************************************
 # Outer launcher script for "bazel run"
 
-_bazelrun_script_template = """
-#!/bin/bash
+_bazelrun_script_template = """#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
ibazel was failing to run this script because of the newline before the shebang. Strangely, `bazel run` worked fine, but `file <script>` also cares about the newline so I don't think this is really an ibazel bug.

Fixes #143 