### PR TITLE
fix module metadata

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "rules_spring",
-    version = "2.5.0",
+    version = "2.5.1",
     compatibility_level = 2,
     repo_name = "rules_spring",
 )
@@ -22,7 +22,7 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Maven dependencies for the examples
 bazel_dep(name = "rules_jvm_external", version = "6.6", dev_dependency = True)
-maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
 maven.install(
     artifacts = [
         "org.slf4j:slf4j-api:2.0.13",

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,12 @@ Navigate into our examples directories:
 - [Hello World](helloworld): bare bones example
 - [Demo App](demoapp): demonstrates how to use various features in the rule
 
+The examples above are coresident with the rule itself, which makes them not precise.
+Your usage of rules_spring will be as a remote repository.
+These same examples are availabe in a dedicated repository:
+
+- [External Demos](https://github.com/plaird/rules_spring_demoapp)
+
 There is also a Kotlin example, which is kept in a separate branch in this repository:
 
 - [KotlinApp](https://github.com/salesforce/rules_spring/tree/examples_kotlin) shows how to build and run  Spring Boot applications written in Kotlin with *rules_spring*


### PR DESCRIPTION
Have built a proper, publicly facing, external test app, and discovered an issue in the module metadata.

Formerly, I would use our internal monorepo for testing. But it isn't on Bzlmod yet, so I was hindered in testing.