### PR TITLE
enhance docs for attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ We may check breaking changes into *main* at any time.
 
 This is largely outside the scope of *rules_spring*.
 You will need to update your dependencies in your *maven_install* rules, of course.
+But there are [a ton of other steps](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide).
+Salesforce has some [docs/tools that will help](https://github.com/spring-projects/spring-boot/issues/43528) for Bazel users.
 
 The one change that you will need to make for *rules_spring* is to choose the Boot3 launcher class.
 This is because Boot rewrote the launcher for Boot3 and it is available under a different name.

--- a/springboot/springboot_doc.md
+++ b/springboot/springboot_doc.md
@@ -1,8 +1,50 @@
-<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+## Springboot() Attributes
 
-<a name="#springboot"></a>
+This doc explains conventions and reference for the rule attributes.
 
-## springboot
+### Standard Spring Boot Dependencies
+
+The [@rules_spring//springboot/import_bundles](import_bundles) package contains an
+    example list of core set of Spring Boot dependencies.
+We recommend starting with this list, and then creating your own lists that fit your needs.
+
+
+### Pattern of Repo-Wide Defaults
+
+Do you want to provide a default value for an attribute, across all _springboot()_ invocations in your repo?
+There is a pattern for that.
+This is just standard Bazel, nothing specific to *rules_spring*.
+
+First, create a Bazel file somewhere in your repo, with a function like this:
+```
+def mycompany_springboot(**kwargs):
+
+    # OVERRIDE: The rules_spring default list is [], which is too strict for mycompany,
+    #   open up some modules if the caller does not override it.
+    if kwargs.get("bazelrun_addopens") == None:
+        kwargs["bazelrun_addopens"] = [        
+            "java.base/java.base=ALL-UNNAMED",
+            "java.base/java.io=ALL-UNNAMED",
+            "java.base/java.math=ALL-UNNAMED",
+        ]
+
+    # And then delegate to the default impl
+    springboot(**kwargs)
+```
+
+And then use your function in your BUILD file like:
+```
+load("//tools/mycompany:myutils.bzl", "mycompany_springboot",
+
+mycompany_springboot(
+    name = "myapp",
+    java_library = ":base_lib",
+    boot_app_class = "com.mycompany.MyApp",
+)
+```
+
+
+### Attrbute Reference
 
 <pre>
 springboot(<a href="#springboot-name">name</a>, <a href="#springboot-java_library">java_library</a>, <a href="#springboot-boot_app_class">boot_app_class</a>, <a href="#springboot-deps">deps</a>, <a href="#springboot-deps_exclude">deps_exclude</a>, <a href="#springboot-deps_exclude_paths">deps_exclude_paths</a>,


### PR DESCRIPTION
Improved our docs for attributes, and added some doc links for the [SpringBoot3 upgrade Issue](https://github.com/salesforce/rules_spring/issues/230) I created.

It finally closes out #78 by providing a simple example.
We ended up not doing that in our monorepo for years, until today.