### PR TITLE
fix bazelrun jvmflags, add list attribute

### DIFF
--- a/springboot/default_bazelrun_script.sh
+++ b/springboot/default_bazelrun_script.sh
@@ -55,14 +55,6 @@ echo ""
 echo "Using JAVA_OPTS from the environment: ${JAVA_OPTS}"
 echo "Using bazelrun_jvm_flags from the BUILD file: ${JVM_FLAGS}"
 
-if [ -f "${ADD_EXPORTS}" ]; then
-  echo "Using ADD_EXPORTS from the environment: ${ADD_EXPORTS}"
-fi
-
-if [ -f "${ADD_OPENS}" ]; then
-  echo "Using ADD_OPENS from the environment: ${ADD_OPENS}"
-fi
-
 # main args
 main_args="$@"
 
@@ -72,7 +64,7 @@ jar=${SPRINGBOOTJAR_FILENAME}
 
 # assemble the command
 # use exec so that we can pass signals to the underlying process (https://github.com/salesforce/rules_spring/issues/91)
-cmd="exec ${java_cmd} ${JVM_FLAGS} ${JAVA_OPTS} ${ADD_EXPORTS} ${ADD_OPENS} -jar ${path}${jar} ${main_args}"
+cmd="exec ${java_cmd} ${JVM_FLAGS} ${JAVA_OPTS} -jar ${path}${jar} ${main_args}"
 
 echo "Running ${cmd}"
 echo "In directory $(pwd)"

--- a/springboot/springboot.bzl
+++ b/springboot/springboot.bzl
@@ -380,6 +380,7 @@ def springboot(
         bazelrun_java_toolchain = None,
         bazelrun_script = None,
         bazelrun_jvm_flags = None,
+        bazelrun_jvm_flag_list = None,
         bazelrun_data = None,
         bazelrun_background = False,
         addins = [],
@@ -441,8 +442,9 @@ def springboot(
       bazelrun_java_toolchain: Optional. Label to the Java toolchain to use when launching the application using 'bazel run'
       bazelrun_script: Optional. When launching the application using 'bazel run', a default launcher script is used.
         This attribute can be used to provide a customized launcher script. Ex: *my_custom_script.sh*
-      bazelrun_jvm_flags: Optional. When launching the application using 'bazel run', an optional set of JVM flags
-        to pass to the JVM at startup. Ex: *-Dcustomprop=gold -DcustomProp2=silver*
+      bazelrun_jvm_flags: Optional. Deprecated form of bazelrun_jvm_flag_list. Ex: *-Dcustomprop=gold -DcustomProp2=silver*
+      bazelrun_jvm_flag_list: Optional. When launching the application using 'bazel run', an optional set of JVM flags
+        to pass to the JVM at startup. Ex: *['-Dcustomprop=gold', '-DcustomProp2=silver']*
       bazelrun_data: Uncommon option to add data files to runfiles. Behaves like the *data* attribute defined for *java_binary*.
       bazelrun_background: Optional. If True, the *bazel run* launcher will not block. The run command will return and process will remain running.
       addins: Uncommon option to add additional files to the root of the springboot jar. For example a license file. Pass an array of files from the package.
@@ -488,6 +490,10 @@ def springboot(
         dupeclassescheck_ignorelist = duplicate_class_allowlist
     if bazelrun_jvm_flags == None:
         bazelrun_jvm_flags = jvm_flags
+    if bazelrun_jvm_flags == None:
+        bazelrun_jvm_flags = ""
+    if bazelrun_jvm_flag_list != None:
+        bazelrun_jvm_flags = bazelrun_jvm_flags + " ".join(bazelrun_jvm_flag_list)
     if bazelrun_data == None:
         bazelrun_data = data
 

--- a/springboot/write_bazelrun_env.sh
+++ b/springboot/write_bazelrun_env.sh
@@ -17,21 +17,13 @@ SPRINGBOOTJAR_FILENAME=${2}
 LABEL_PATH=${3}
 OUTPUTFILE_PATH=${4}
 DO_BACKGROUND=${5}
-ADD_EXPORTS=${6}
-ADD_OPENS=${7}
-FIRST_JVMFLAG_ARG=8
+FIRST_JVMFLAG_ARG=6
 
 if [ "$LABEL_PATH" == "root" ]; then
     # token that indicates that the target is in the root path, which for the
     # purposes of the label path, is empty string
     LABEL_PATH=""
 fi
-
-#echo "Generating 'bazel run' env."
-#echo "SPRINGBOOTJAR_FILENAME=$SPRINGBOOTJAR_FILENAME"
-#echo "LABEL_PATH=$LABEL_PATH"
-#echo "OUTPUTFILE_PATH=$OUTPUTFILE_PATH"
-#echo "DO_BACKGROUND=$DO_BACKGROUND"
 
 JVM_FLAGS=""
 i=$FIRST_JVMFLAG_ARG
@@ -45,6 +37,14 @@ echo "export RULE_NAME=$RULE_NAME" > $OUTPUTFILE_PATH
 echo "export LABEL_PATH=$LABEL_PATH" >> $OUTPUTFILE_PATH
 echo "export SPRINGBOOTJAR_FILENAME=$SPRINGBOOTJAR_FILENAME" >> $OUTPUTFILE_PATH
 echo "export DO_BACKGROUND=$DO_BACKGROUND" >> $OUTPUTFILE_PATH
-echo "export ADD_EXPORTS=$ADD_EXPORTS" >> $OUTPUTFILE_PATH
-echo "export ADD_OPENS=$ADD_OPENS" >> $OUTPUTFILE_PATH
 echo "export JVM_FLAGS=\"$JVM_FLAGS\"" >> $OUTPUTFILE_PATH
+
+
+# DEBUG output
+#echo "Generating 'bazel run' env."
+#echo "SPRINGBOOTJAR_FILENAME=$SPRINGBOOTJAR_FILENAME"
+#echo "LABEL_PATH=$LABEL_PATH"
+#echo "OUTPUTFILE_PATH=$OUTPUTFILE_PATH"
+#echo "DO_BACKGROUND=$DO_BACKGROUND"
+#echo "JVM_FLAGS=$JVM_FLAGS"
+


### PR DESCRIPTION
Two updates:
- New attribute *bazelrun_jvm_flag_list* is the new form of *bazelrun_jvm_flags* but is more bazel-like: it is an array of JVM args, instead of a space separated string
- Discovered that ADD_OPENS and ADD_EXPORTS bazel run script variables were not working correctly in some cases. There was no delineation between them and JVM_FLAGS and so in some cases jvm flags were being processed as ADDs. Removed those two variables since ADDs can just be treated as additional JVM_FLAGS in a single list.