### PR TITLE
demo updates: fix autoconfigs, add jvmflags for bazel run

### DIFF
--- a/examples/demoapp/BUILD
+++ b/examples/demoapp/BUILD
@@ -109,8 +109,18 @@ springboot(
     deps_banned = ["junit", "mockito", "lombok"],
 
     # Specify optional JVM args to use when the application is launched with 'bazel run'
-    bazelrun_jvm_flags = "-Dcustomprop=gold -DcustomProp2=silver",
-
+    bazelrun_jvm_flags = "-Dcustomprop=gold -DcustomProp2=silver", # old way
+    bazelrun_jvm_flag_list = ["-Dcustomprop3=bronze", "-DcustomProp4=copper"], # new way
+    bazelrun_addexports = [
+        "java.base/java.base=ALL-UNNAMED",
+        "java.base/java.io=ALL-UNNAMED",
+        "java.base/java.nio=ALL-UNNAMED",
+    ],
+    bazelrun_addopens = [
+        "java.base/java.util.concurrent=ALL-UNNAMED",
+        "java.base/java.util.logging=ALL-UNNAMED",
+    ],
+    
     # data files can be made available in the working directory for when the app is launched with bazel run
     bazelrun_data = ["example_data.txt"],
 

--- a/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
+++ b/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
@@ -7,6 +7,11 @@ import org.springframework.boot.loader.tools.SignalUtils;
 public class SampleAutoConfiguration {
 
     @PostConstruct
+    public void logLoadedProperties() {
+        System.out.println("Loading SampleAutoConfiguration.");
+    }
+
+    @PostConstruct
     public void setupSignalHandler() {
         // SignalUtils is really limited, it only attaches to the INT signal (2)
         // You could steal the code and attach to other signals.

--- a/examples/demoapp/src/main/resources/META-INF/spring.factories
+++ b/examples/demoapp/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.sample.SampleAutoConfiguration

--- a/examples/demoapp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/examples/demoapp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.sample.SampleAutoConfiguration

--- a/examples/helloworld/src/main/resources/META-INF/spring.factories
+++ b/examples/helloworld/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.sample.SampleAutoConfiguration

--- a/examples/helloworld/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/examples/helloworld/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.sample.SampleAutoConfiguration


### PR DESCRIPTION
Updates for the demos:
- fixed auto configs (missed in the earlier Boot3 upgrade)
- added more bazel run jvm flags to the demoapp