### PR TITLE
support external application.properties files for bazel run

### DIFF
--- a/examples/demoapp/BUILD
+++ b/examples/demoapp/BUILD
@@ -76,6 +76,16 @@ java_test(
    deps = [ ":demoapp_lib" ] + test_deps,
 )
 
+filegroup(
+    name = "bazelrun_data_files",
+    srcs = [
+        "application.properties",
+        "application-dev.properties",
+        "config/application.properties",
+        "example_data.txt"
+    ],
+)
+
 # Build the app as a Spring Boot executable jar
 # To launch: bazel run //examples/demoapp
 springboot(
@@ -122,7 +132,7 @@ springboot(
     ],
     
     # data files can be made available in the working directory for when the app is launched with bazel run
-    bazelrun_data = ["example_data.txt"],
+    bazelrun_data = [":bazelrun_data_files"],
 
     # run the application in the background (command returns immediately)
     #bazelrun_background = True,

--- a/examples/demoapp/application-dev.properties
+++ b/examples/demoapp/application-dev.properties
@@ -1,0 +1,1 @@
+demoapp.config.rootdirectory=loaded (via dev profile)

--- a/examples/demoapp/application.properties
+++ b/examples/demoapp/application.properties
@@ -1,0 +1,1 @@
+demoapp.config.rootdirectory=loaded

--- a/examples/demoapp/config/application.properties
+++ b/examples/demoapp/config/application.properties
@@ -1,0 +1,1 @@
+demoapp.config.configsubdirectory=loaded

--- a/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
+++ b/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
@@ -1,14 +1,27 @@
 package com.sample;
 
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 
 import org.springframework.boot.loader.tools.SignalUtils;
 
 public class SampleAutoConfiguration {
 
+    @Value("${demoapp.config.internal:not found}")
+    String config_internal;
+
+    @Value("${demoapp.config.rootdirectory:not found}")
+    String config_external_root;
+
+    @Value("${demoapp.config.configsubdirectory:not found}")
+    String config_external_configsub;
+
     @PostConstruct
     public void logLoadedProperties() {
-        System.out.println("Loading SampleAutoConfiguration.");
+        System.out.println("SampleAutoConfiguration loading of application.properties files:");
+        System.out.println("  internal application.properties: "+config_internal);
+        System.out.println("  external application.properties: "+config_external_root);
+        System.out.println("  external config/application.properties: "+config_external_configsub);
     }
 
     @PostConstruct

--- a/examples/demoapp/src/main/resources/application.properties
+++ b/examples/demoapp/src/main/resources/application.properties
@@ -9,3 +9,5 @@
 #  http://localhost:8080/actuator/beans
 #  http://localhost:8080/actuator/info
 management.endpoints.web.exposure.include=*
+
+demoapp.config.internal=loaded

--- a/springboot/bazelrun.md
+++ b/springboot/bazelrun.md
@@ -116,6 +116,32 @@ bazel run //examples/helloworld -- --spring.config.location=/tmp/myconfig/
 
 otherwise Bazel will try to consume the '--' argument for itself.
 
+### External Configuration with application.properties
+
+Spring Boot will load internal application.properties files, typically put in *src/main/resources* and
+add to your *java_library* resources attribute.
+
+But when launching with *bazel run*, you may also provide external application.properties files.
+This is done via Bazel's [data dependencies](https://bazel.build/concepts/dependencies#data-dependencies) capability, surfaced in the *springboot* rule via the *bazelrun_data* attribute.
+
+```
+filegroup(
+    name = "bazelrun_data_files",
+    srcs = [
+        "application.properties",
+        "application-dev.properties",
+        "config/application.properties",
+    ],
+)
+
+springboot(
+    ...
+    bazelrun_data = [":bazelrun_data_files"],
+)
+```
+The default launcher script will detect filenames with pattern _application*.properties_ as being 
+  external configuration files, and configure them as additional configuration files for Spring Boot.
+
 
 ### Custom Launcher Script
 

--- a/springboot/springboot.bzl
+++ b/springboot/springboot.bzl
@@ -604,12 +604,17 @@ def springboot(
         visibility = visibility,
     )
 
+
+
     # SUBRULE 3B: GENERATE THE ENV VARIABLES USED BY THE BAZELRUN LAUNCHER SCRIPT
     genbazelrunenv_out = name + "_bazelrun_env.sh"
     native.genrule(
         name = genbazelrunenv_rule,
+        srcs = bazelrun_data,
         cmd = "$(location @rules_spring//springboot:write_bazelrun_env.sh) " + name + " " + _get_springboot_jar_file_name(name)
             + " " + _get_relative_package_path() + " $@ " + _convert_starlarkbool_to_bashbool(bazelrun_background)
+            + " $(SRCS)"
+            + " start_flags"
             + " " + " ".join(["--add-exports=" + element for element in bazelrun_addexports])
             + " " + " ".join(["--add-opens=" + element for element in bazelrun_addopens])
             + " " + bazelrun_jvm_flags,

--- a/springboot/springboot_doc.md
+++ b/springboot/springboot_doc.md
@@ -44,24 +44,7 @@ mycompany_springboot(
 ```
 
 
-### Attrbute Reference
-
-<pre>
-springboot(<a href="#springboot-name">name</a>, <a href="#springboot-java_library">java_library</a>, <a href="#springboot-boot_app_class">boot_app_class</a>, <a href="#springboot-deps">deps</a>, <a href="#springboot-deps_exclude">deps_exclude</a>, <a href="#springboot-deps_exclude_paths">deps_exclude_paths</a>,
-           <a href="#springboot-deps_index_file">deps_index_file</a>, <a href="#springboot-deps_use_starlark_order">deps_use_starlark_order</a>, <a href="#springboot-dupeclassescheck_enable">dupeclassescheck_enable</a>,
-           <a href="#springboot-dupeclassescheck_ignorelist">dupeclassescheck_ignorelist</a>, <a href="#springboot-include_git_properties_file">include_git_properties_file</a>, <a href="#springboot-bazelrun_script">bazelrun_script</a>,
-           <a href="#springboot-bazelrun_jvm_flags">bazelrun_jvm_flags</a>, <a href="#springboot-bazelrun_data">bazelrun_data</a>, <a href="#springboot-bazelrun_background">bazelrun_background</a>, <a href="#springboot-addins">addins</a>, <a href="#springboot-tags">tags</a>, <a href="#springboot-testonly">testonly</a>, <a href="#springboot-visibility">visibility</a>,
-           <a href="#springboot-exclude">exclude</a>, <a href="#springboot-classpath_index">classpath_index</a>, <a href="#springboot-use_build_dependency_order">use_build_dependency_order</a>, <a href="#springboot-fail_on_duplicate_classes">fail_on_duplicate_classes</a>,
-           <a href="#springboot-duplicate_class_allowlist">duplicate_class_allowlist</a>, <a href="#springboot-jvm_flags">jvm_flags</a>, <a href="#springboot-data">data</a>)
-</pre>
-
-Bazel rule for packaging an executable Spring Boot application.
-
-Note that the rule README has more detailed usage instructions for each attribute.
-
-
-**PARAMETERS**
-
+### Attribute Reference
 
 | Name  | Description | Default Value |
 | :-------------: | :-------------: | :-------------: |
@@ -81,7 +64,8 @@ Note that the rule README has more detailed usage instructions for each attribut
 | bazelrun_java_toolchain |  Optional. When launching the application using 'bazel run', this attribute can identify the label of the Java toolchain used to launch the JVM. Ex: *//tools/jdk:my_default_toolchain*. See *default_java_toolchain* in the Bazel documentation.  |  <code>None</code> |
 | bazelrun_script |  Optional. When launching the application using 'bazel run', a default launcher script is used.   This attribute can be used to provide a customized launcher script. Ex: *my_custom_script.sh*   |  <code>None</code> |
 | bazelrun_jvm_flags |  Optional. When launching the application using 'bazel run', an optional set of JVM flags   to pass to the JVM at startup. Ex: *-Dcustomprop=gold -DcustomProp2=silver*   |  <code>None</code> |
-| bazelrun_data |  Uncommon option to add data files to runfiles. Behaves like the *data* attribute defined for *java_binary*.   |  <code>None</code> |
+| bazelrun_jvm_flag_list |  Optional. When launching the application using 'bazel run', an optional set of JVM flags   to pass to the JVM at startup. Ex: *["-Dcustomprop=gold", "-DcustomProp2=silver*"]   |  <code>None</code> |
+| bazelrun_data |  Option to add data files to runfiles. Behaves like the *data* attribute defined for *java_binary*. See bazel run docs for special behavior when application.properties files are listed here. |  <code>None</code> |
 | bazelrun_background |  Optional. If True, the *bazel run* launcher will not block. The run command will return and process will remain running.   |  <code>False</code> |
 | addins |  Uncommon option to add additional files to the root of the springboot jar. For example a license file. Pass an array of files from the package.   |  <code>[]</code> |
 | tags |  Optional. Bazel standard attribute.   |  <code>[]</code> |

--- a/springboot/write_bazelrun_env.sh
+++ b/springboot/write_bazelrun_env.sh
@@ -17,7 +17,7 @@ SPRINGBOOTJAR_FILENAME=${2}
 LABEL_PATH=${3}
 OUTPUTFILE_PATH=${4}
 DO_BACKGROUND=${5}
-FIRST_JVMFLAG_ARG=6
+start_varargs=6
 
 if [ "$LABEL_PATH" == "root" ]; then
     # token that indicates that the target is in the root path, which for the
@@ -25,11 +25,22 @@ if [ "$LABEL_PATH" == "root" ]; then
     LABEL_PATH=""
 fi
 
+
+DATAFILES=""
 JVM_FLAGS=""
-i=$FIRST_JVMFLAG_ARG
+flags_started=0
+i=$start_varargs
 while [ "$i" -le "$#" ]; do
-  eval "FLAG=\${$i}"
-  JVM_FLAGS="$JVM_FLAGS $FLAG"
+  eval "arg=\${$i}"
+  if [ "$arg" = "start_flags" ]; then
+    flags_started=1
+  else
+    if [ $flags_started -eq 1 ]; then
+      JVM_FLAGS="$JVM_FLAGS $arg"
+    else
+      DATAFILES="${DATAFILES}$arg "
+    fi
+  fi
   i=$((i + 1))
 done
 
@@ -37,7 +48,13 @@ echo "export RULE_NAME=$RULE_NAME" > $OUTPUTFILE_PATH
 echo "export LABEL_PATH=$LABEL_PATH" >> $OUTPUTFILE_PATH
 echo "export SPRINGBOOTJAR_FILENAME=$SPRINGBOOTJAR_FILENAME" >> $OUTPUTFILE_PATH
 echo "export DO_BACKGROUND=$DO_BACKGROUND" >> $OUTPUTFILE_PATH
+echo "export DATAFILES=\"$DATAFILES\"" >> $OUTPUTFILE_PATH
 echo "export JVM_FLAGS=\"$JVM_FLAGS\"" >> $OUTPUTFILE_PATH
+
+if [ -f "$LABEL_PATH/application.properties" ]; then
+    echo "BAZELRUN: Found external app props"
+    echo "export USE_EXTERNAL_CONFIG=true" >> $OUTPUTFILE_PATH
+fi
 
 
 # DEBUG output
@@ -46,5 +63,10 @@ echo "export JVM_FLAGS=\"$JVM_FLAGS\"" >> $OUTPUTFILE_PATH
 #echo "LABEL_PATH=$LABEL_PATH"
 #echo "OUTPUTFILE_PATH=$OUTPUTFILE_PATH"
 #echo "DO_BACKGROUND=$DO_BACKGROUND"
+#echo "DATAFILES=$DATAFILES"
 #echo "JVM_FLAGS=$JVM_FLAGS"
+#echo "CURRENT DIR: $(pwd)"
+#echo "LABEL_PATH: $LABEL_PATH"
+
+
 


### PR DESCRIPTION
Clarifies support for data files in the bazel run launcher script.

Additionally, the launcher script will now detect application.properties files and configure them as external configuration files for Spring Boot.

Solves #135 