### PR TITLE
support bazel run env variables

### DIFF
--- a/examples/demoapp/BUILD
+++ b/examples/demoapp/BUILD
@@ -121,6 +121,10 @@ springboot(
     # Specify optional JVM args to use when the application is launched with 'bazel run'
     bazelrun_jvm_flags = "-Dcustomprop=gold -DcustomProp2=silver", # old way
     bazelrun_jvm_flag_list = ["-Dcustomprop3=bronze", "-DcustomProp4=copper"], # new way
+    # Specify optional environment variables to set when the application is launched with 'bazel run'
+    bazelrun_env_flag_list = ["PROP1=blue", "PROP2=green"],
+
+    # add JVM exports/opens for Java modularization
     bazelrun_addexports = [
         "java.base/java.base=ALL-UNNAMED",
         "java.base/java.io=ALL-UNNAMED",

--- a/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
+++ b/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
@@ -16,12 +16,21 @@ public class SampleAutoConfiguration {
     @Value("${demoapp.config.configsubdirectory:not found}")
     String config_external_configsub;
 
+    @Value("${prop1:not found}")
+    String config_external_env_prop1;
+
+    @Value("${prop2:not found}")
+    String config_external_env_prop2;
+
     @PostConstruct
     public void logLoadedProperties() {
         System.out.println("SampleAutoConfiguration loading of application.properties files:");
         System.out.println("  internal application.properties: "+config_internal);
         System.out.println("  external application.properties: "+config_external_root);
         System.out.println("  external config/application.properties: "+config_external_configsub);
+        System.out.println("SampleAutoConfiguration loading of environment variables:");
+        System.out.println("  PROP1: "+config_external_env_prop1);
+        System.out.println("  PROP2: "+config_external_env_prop2);
     }
 
     @PostConstruct

--- a/springboot/bazelrun.md
+++ b/springboot/bazelrun.md
@@ -142,6 +142,28 @@ springboot(
 The default launcher script will detect filenames with pattern _application*.properties_ as being 
   external configuration files, and configure them as additional configuration files for Spring Boot.
 
+### External Configuration with Environment Variables
+
+Spring Boot will read in [shell environment variables](https://docs.spring.io/spring-boot/reference/features/external-config.html) 
+  as external configuration.
+This technique can be used to set individual configuration properties.
+
+This is surfaced in the *springboot* rule using the *bazelrun_env_flag_list* attribute, which is set as an array
+  of environment variables.
+
+```
+springboot(
+    ...
+    bazelrun_env_flag_list = ["PROP1=blue", "PROP2=green"],
+)
+```
+
+which could then be used in @Value annotations using lowercased names:
+
+```
+    @Value("${prop1:not found}")
+    String prop1;
+```
 
 ### Custom Launcher Script
 

--- a/springboot/springboot.bzl
+++ b/springboot/springboot.bzl
@@ -382,6 +382,7 @@ def springboot(
         bazelrun_script = None,
         bazelrun_jvm_flags = None,
         bazelrun_jvm_flag_list = None,
+        bazelrun_env_flag_list = None,
         bazelrun_data = None,
         bazelrun_background = False,
         addins = [],
@@ -446,6 +447,8 @@ def springboot(
       bazelrun_jvm_flags: Optional. Deprecated form of bazelrun_jvm_flag_list. Ex: *-Dcustomprop=gold -DcustomProp2=silver*
       bazelrun_jvm_flag_list: Optional. When launching the application using 'bazel run', an optional set of JVM flags
         to pass to the JVM at startup. Ex: *['-Dcustomprop=gold', '-DcustomProp2=silver']*
+      bazelrun_env_flag_list: Optional. When launching the application using 'bazel run', an optional set of environment
+        variables to pass to the launcher script at startup. Ex: *['PROP1=gold', 'PROP2=silver']*
       bazelrun_data: Uncommon option to add data files to runfiles. Behaves like the *data* attribute defined for *java_binary*.
       bazelrun_background: Optional. If True, the *bazel run* launcher will not block. The run command will return and process will remain running.
       addins: Uncommon option to add additional files to the root of the springboot jar. For example a license file. Pass an array of files from the package.
@@ -495,6 +498,9 @@ def springboot(
         bazelrun_jvm_flags = ""
     if bazelrun_jvm_flag_list != None:
         bazelrun_jvm_flags = bazelrun_jvm_flags + " ".join(bazelrun_jvm_flag_list)
+    bazelrun_env_flags = ""
+    if bazelrun_env_flag_list != None:
+        bazelrun_env_flags = " ".join(bazelrun_env_flag_list)
     if bazelrun_data == None:
         bazelrun_data = data
 
@@ -617,7 +623,9 @@ def springboot(
             + " start_flags"
             + " " + " ".join(["--add-exports=" + element for element in bazelrun_addexports])
             + " " + " ".join(["--add-opens=" + element for element in bazelrun_addopens])
-            + " " + bazelrun_jvm_flags,
+            + " " + bazelrun_jvm_flags
+            + " start_envs"
+            + " " + bazelrun_env_flags,
         #      message = "SpringBoot rule is writing the bazel run launcher env...",
         tools = ["@rules_spring//springboot:write_bazelrun_env.sh"],
         outs = [genbazelrunenv_out],


### PR DESCRIPTION
Allows the springboot() invocation to specify environment variables that will be loaded into the bazel run launcher script. These could be used to set individual spring properties.

```
# Specify optional environment variables to set when the application is launched with 'bazel run'
    bazelrun_env_flag_list = ["PROP1=blue", "PROP2=green"],
```

Solves #166 