### PR TITLE
failed attempt at using java_runtime_version for bazel run [do not merge]

### DIFF
--- a/springboot/default_bazelrun_script.sh
+++ b/springboot/default_bazelrun_script.sh
@@ -35,6 +35,9 @@ current_dir=$(pwd)
 if [ -f "${BAZEL_RUN_JAVA}" ]; then
   echo "Selected the JVM using the BAZEL_RUN_JAVA environment variable."
   java_cmd=$BAZEL_RUN_JAVA
+elif [ -f "$JAVA_RUNTIME" ]; then
+  echo "Selected the JVM using the Bazel Java Runtime: $JAVA_RUNTIME"
+  java_cmd=$JAVA_RUNTIME
 elif [ -f "$JAVA_TOOLCHAIN" ]; then
   echo "Selected the JVM using the Bazel Java toolchain: $JAVA_TOOLCHAIN_NAME"
   java_cmd=$JAVA_TOOLCHAIN


### PR DESCRIPTION
Just some failed attempts at #16 publishing as a PR just to have a record of what I have tried.

This PR works as expected if you specify tool runtime in your run command:
```
bazel run --tool_java_runtime_version=remotejdk_17  examples/helloworld 
bazel run --tool_java_runtime_version=remotejdk_21  examples/helloworld 
```

But does **not** work:
- if the parameter ```java_runtime_version``` is used, which I would expect to work
- by default, Bazel is picking 11 for tool runtime, so this will break workspaces where users need 17+ (Boot3) and don't define the version in .bazelrc

If we can find a solution this should only occur in a major upgrade in rules_spring because of the many cases that may break. I am personally confused by all of the bugs and changes in the java toolchain resolution in Bazel over the years, and changing anything in rules_spring that touches that should be done with great care.

- https://github.com/bazelbuild/bazel/issues/18265
- https://github.com/bazelbuild/bazel/pull/18262
- https://github.com/bazelbuild/bazel/issues/21915