### PR TITLE
add example for BuildProperties

### DIFF
--- a/examples/demoapp/BUILD
+++ b/examples/demoapp/BUILD
@@ -13,6 +13,7 @@
 load("//springboot:springboot.bzl", "springboot")
 load("//springboot:deps_filter_transitive.bzl", "deps_filter_transitive")
 load("//tools/license:licenses_used.bzl", "licenses_used")
+load(":generate-build-info.bzl", "gen_buildinfo_rule")
 
 # dependencies from other packages in the workspace
 deps = [
@@ -40,7 +41,6 @@ springboot_deps = [
 # covers this case, and this snippet shows how to use it:
 deps_filter_transitive(
     name = "filtered_deps",
-    deps = springboot_deps + deps, # the input list
     deps_exclude = [
         # tomcat comes in transitively, but we want to use jetty
         "@maven//:org_apache_tomcat_embed_tomcat_embed_core",
@@ -51,13 +51,14 @@ deps_filter_transitive(
         "@maven//:javax_annotation_javax_annotation_api",
     ],
     exclude_transitives = True,
+    deps = springboot_deps + deps,  # the input list
 )
 
 # This Java library contains the app code
 java_library(
     name = "demoapp_lib",
     srcs = glob(["src/main/java/**/*.java"]),
-    resources = glob(["src/main/resources/**"]),
+    resources = glob(["src/main/resources/**"]) + [":generate_build_info"],
     deps = [":filtered_deps"],
 )
 
@@ -74,9 +75,9 @@ test_deps = [
 ]
 
 java_test(
-   name = "SampleRestUnitTest",
-   srcs = ["src/test/java/com/sample/SampleRestUnitTest.java"],
-   deps = [ ":demoapp_lib" ] + test_deps,
+    name = "SampleRestUnitTest",
+    srcs = ["src/test/java/com/sample/SampleRestUnitTest.java"],
+    deps = [":demoapp_lib"] + test_deps,
 )
 
 filegroup(
@@ -85,7 +86,7 @@ filegroup(
         "application.properties",
         "application-dev.properties",
         "config/application.properties",
-        "example_data.txt"
+        "example_data.txt",
     ],
 )
 
@@ -93,39 +94,13 @@ filegroup(
 # To launch: bazel run //examples/demoapp
 springboot(
     name = "demoapp",
-    boot_app_class = "com.sample.SampleMain",
-    java_library = ":demoapp_lib",
 
-    # SPRING BOOT 3
-    # The launcher class changed in between Boot2 and Boot3, so we provide the
-    # Boot3 launcher class here (the Boot2 one is the default)
-    boot_launcher_class = 'org.springframework.boot.loader.launch.JarLauncher',
-
-    # DEPS ARE OPTIONAL HERE
-    #  The springboot rule inherits all deps and runtime_deps from the java_library()
-    #  but this jar for uncommon reason is just added to the springboot rule.
-    deps = [ ":rootclassloader_lib", ],
-
-    # TO TEST THE DUPE CLASSES FEATURE:
-    #   There is an intentionally duplicated class in lib1 and lib2. Do this:
-    #   1. set fail_on_duplicate_classes = True
-    #   2. comment out lib1 or lib2 in demoapp_dupeclass_allowlist.txt
-    #   Build should fail due to the duplicate class.
-    dupeclassescheck_enable = True,
-    dupeclassescheck_ignorelist = "demoapp_dupeclass_allowlist.txt",
-
-    # BANNED DEPS
-    # These are dependencies that you never want in your springboot jar.
-    # This is used to detect mistakes in your transitive dependency graph. They
-    # might be test jars, or compile time jars like lombok. The list of strings
-    # is matched against the dependency jar filenames with a 'contains' match.
-    deps_banned = ["junit", "mockito", "lombok"],
-
-    # Specify optional JVM args to use when the application is launched with 'bazel run'
-    bazelrun_jvm_flags = "-Dcustomprop=gold -DcustomProp2=silver", # old way
-    bazelrun_jvm_flag_list = ["-Dcustomprop3=bronze", "-DcustomProp4=copper"], # new way
-    # Specify optional environment variables to set when the application is launched with 'bazel run'
-    bazelrun_env_flag_list = ["PROP1=blue", "PROP2=green"],
+    # sometimes packagers want to put certain files into the root of the springboot app jar
+    # these addins will be copied into the root of the generated springboot jar
+    addins = [
+        ":info.txt",
+        ":author.txt",
+    ],
 
     # add JVM exports/opens for Java modularization
     bazelrun_addexports = [
@@ -137,9 +112,38 @@ springboot(
         "java.base/java.util.concurrent=ALL-UNNAMED",
         "java.base/java.util.logging=ALL-UNNAMED",
     ],
-    
+
     # data files can be made available in the working directory for when the app is launched with bazel run
     bazelrun_data = [":bazelrun_data_files"],
+    # Specify optional environment variables to set when the application is launched with 'bazel run'
+    bazelrun_env_flag_list = [
+        "PROP1=blue",
+        "PROP2=green",
+    ],
+    bazelrun_jvm_flag_list = [
+        "-Dcustomprop3=bronze",
+        "-DcustomProp4=copper",
+    ],  # new way
+
+    # Specify optional JVM args to use when the application is launched with 'bazel run'
+    bazelrun_jvm_flags = "-Dcustomprop=gold -DcustomProp2=silver",  # old way
+    boot_app_class = "com.sample.SampleMain",
+
+    # SPRING BOOT 3
+    # The launcher class changed in between Boot2 and Boot3, so we provide the
+    # Boot3 launcher class here (the Boot2 one is the default)
+    boot_launcher_class = "org.springframework.boot.loader.launch.JarLauncher",
+
+    # BANNED DEPS
+    # These are dependencies that you never want in your springboot jar.
+    # This is used to detect mistakes in your transitive dependency graph. They
+    # might be test jars, or compile time jars like lombok. The list of strings
+    # is matched against the dependency jar filenames with a 'contains' match.
+    deps_banned = [
+        "junit",
+        "mockito",
+        "lombok",
+    ],
 
     # run the application in the background (command returns immediately)
     #bazelrun_background = True,
@@ -148,9 +152,19 @@ springboot(
     #  https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-executable-jar-format.html#executable-jar-war-index-files-classpath
     deps_index_file = ":demoapp_classpath.idx",
 
-    # sometimes packagers want to put certain files into the root of the springboot app jar
-    # these addins will be copied into the root of the generated springboot jar
-    addins = [":info.txt", ":author.txt"],
+    # TO TEST THE DUPE CLASSES FEATURE:
+    #   There is an intentionally duplicated class in lib1 and lib2. Do this:
+    #   1. set fail_on_duplicate_classes = True
+    #   2. comment out lib1 or lib2 in demoapp_dupeclass_allowlist.txt
+    #   Build should fail due to the duplicate class.
+    dupeclassescheck_enable = True,
+    dupeclassescheck_ignorelist = "demoapp_dupeclass_allowlist.txt",
+    java_library = ":demoapp_lib",
+
+    # DEPS ARE OPTIONAL HERE
+    #  The springboot rule inherits all deps and runtime_deps from the java_library()
+    #  but this jar for uncommon reason is just added to the springboot rule.
+    deps = [":rootclassloader_lib"],
 )
 
 springboottest_deps = [
@@ -162,8 +176,8 @@ springboottest_deps = [
 java_test(
     name = "SampleRestFuncTest",
     srcs = ["src/test/java/com/sample/SampleRestFuncTest.java"],
-    deps = [ ":demoapp_lib" ] + test_deps + springboottest_deps,
     resources = glob(["src/test/resources/**"]),
+    deps = [":demoapp_lib"] + test_deps + springboottest_deps,
 )
 
 licenses_used(
@@ -177,11 +191,21 @@ licenses_used(
 # To launch: bazel run //examples/demoapp:demoapp-second
 springboot(
     name = "demoapp-second",
-    boot_app_class = "com.sample.SampleMain",
-    java_library = ":demoapp_lib",
-    boot_launcher_class = 'org.springframework.boot.loader.launch.JarLauncher',
-    deps = [ ":rootclassloader_lib", ],
 
     # you may choose to override the launcher script that is used when you invoke 'bazel run //examples/demoapp'
     bazelrun_script = "custom_bazelrun_script.sh",
+    boot_app_class = "com.sample.SampleMain",
+    boot_launcher_class = "org.springframework.boot.loader.launch.JarLauncher",
+    java_library = ":demoapp_lib",
+    deps = [":rootclassloader_lib"],
+)
+
+# BuildProperties Support
+# See the generate-build-info.sh for usage details.
+exports_files([
+    "generate-build-info.sh",
+])
+
+gen_buildinfo_rule(
+    name = "generate_build_info",
 )

--- a/examples/demoapp/README.md
+++ b/examples/demoapp/README.md
@@ -13,6 +13,16 @@ To run:
 
 ```bash
 bazel run //examples/demoapp
+
+# or to see build data in the endpoint, run like this:
+bazel run --action_env=BUILD_NUMBER=998 --action_env=BUILD_TAG=green examples/demoapp
 ```
 
-For full documentation, see the [//springboot](../../springboot) package documentation.
+Endpoints:
+```
+http://localhost:8080/
+http://localhost:8080/actuator/configprops
+http://localhost:8080/actuator/info
+```
+
+For full documentation of rules_spring, see the [//springboot](../../springboot) package documentation.

--- a/examples/demoapp/generate-build-info.bzl
+++ b/examples/demoapp/generate-build-info.bzl
@@ -1,0 +1,11 @@
+# This macro runs a shell script to implant build variables into a properties file,
+# which is in turn consumed by Spring's BuildProperties bean. See the script for
+# usage details.
+
+def gen_buildinfo_rule(name, output = "src/main/resources/META-INF/build-info.properties"):
+    native.genrule(
+        name = name,
+        cmd = """$(location //examples/demoapp:generate-build-info.sh) $@""",
+        tools = ["//examples/demoapp:generate-build-info.sh"],
+        outs = [output],
+    )

--- a/examples/demoapp/generate-build-info.sh
+++ b/examples/demoapp/generate-build-info.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# This script is invoked by generate-build-info.bzl, which is in turn invoked by
+# the BUILD file. Consult those files for usage info.
+
+# This script implants build data into the Spring Boot app, which is then
+# accessible by autowiring the org.springframework.boot.info.BuildProperties bean.
+# See SampleAutoConfiguration.java for an example usage of BuildProperties.
+
+buildpropsfile=$1
+
+# These must be set by the bazel command that launches the app.
+# bazel run --action_env=BUILD_NUMBER=998 --action_env=BUILD_TAG=green examples/demoapp
+
+echo "build.number=$BUILD_NUMBER" >> $buildpropsfile
+echo "build.tag=$BUILD_TAG" >> $buildpropsfile

--- a/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
+++ b/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
@@ -1,8 +1,9 @@
 package com.sample;
 
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.loader.tools.SignalUtils;
 
 public class SampleAutoConfiguration {
@@ -22,6 +23,14 @@ public class SampleAutoConfiguration {
     @Value("${prop2:not found}")
     String config_external_env_prop2;
 
+    /**
+     * BuildProperties is a Spring facility for implanting build data into the app.
+     * This is not enabled by default for rules_spring. You must wire it up using
+     * the example code in generate-build-info.sh
+     */
+    @Autowired
+    private BuildProperties buildProperties;
+
     @PostConstruct
     public void logLoadedProperties() {
         System.out.println("SampleAutoConfiguration loading of application.properties files:");
@@ -31,6 +40,10 @@ public class SampleAutoConfiguration {
         System.out.println("SampleAutoConfiguration loading of environment variables:");
         System.out.println("  PROP1: "+config_external_env_prop1);
         System.out.println("  PROP2: "+config_external_env_prop2);
+        System.out.println("SampleAutoConfiguration loading of BuildProperties:");
+        System.out.println("  (set BUILD_NUMBER and BUILD_TAG action_env variables for Bazel build to use)");
+        System.out.println("  build.number: "+buildProperties.get("number"));
+        System.out.println("  build.tag: "+buildProperties.get("tag"));
     }
 
     @PostConstruct


### PR DESCRIPTION
Provides a working example of using Spring's BuildProperties bean. Thanks @MohitBhar for creating the internal version of this, that I extracted into this example.

Run:
```bash
bazel run --action_env=BUILD_NUMBER=998 --action_env=BUILD_TAG=green examples/demoapp  
```
and then check:
```
http://localhost:8080/actuator/info
```

vscode/ij reordered the BUILD file, unfortunately.