### PR TITLE
Sanitize libdir to avoid URL encoding issues

### DIFF
--- a/springboot/springboot_pkg.sh
+++ b/springboot/springboot_pkg.sh
@@ -174,6 +174,12 @@ while [ "$i" -le "$#" ]; do
   libname=$(basename $lib)
   libdir=$(dirname $lib)
   echo "DEBUG: libname: $libname" >> $debugfile
+  echo "DEBUG: libdir: $libdir" >> $debugfile
+  # Some paths may contain % as a result of Bazel URL encoding the folder name, such as
+  # user@example.com becoming user%40example.com. Such folders fail to load (see Issue #270).
+  # Translate % to _ to avoid this issue.
+  libdir=${libdir//%/_}
+  echo "DEBUG: sanitized libdir: $libdir" >> $debugfile
   if [[ $libname == *jar ]]; then
     # we only want to process .jar files as libs
     if [[ $libname == *spring-boot-loader* ]] || [[ $libname == *spring_boot_loader* ]] || [[ $libname == librootclassloader_lib* ]]; then


### PR DESCRIPTION
**Problem:** Bazel, when using a private repo like Artifactory, will URL encode paths, such as `user@example.com` to `user%40example.com`. When copying over jars with that path into lib, such jars are not correctly loaded by Spring.

**Solution:** Since the paths would not load correctly anyway sanitize libdir such that `%` is translated to `_`, keeping the path readable, but functional. `user%40example.com` --> `user_40example.com`.

**Result:** Spring now correctly loads in jars when Bazel fetches them from a private Artifactory repo.