### PR TITLE
Fail springboot builds when their validation checks fail

### DIFF
--- a/examples/demoapp/BUILD
+++ b/examples/demoapp/BUILD
@@ -204,6 +204,9 @@ springboot(
     bazelrun_script = "custom_bazelrun_script.sh",
     boot_app_class = "com.sample.SampleMain",
     boot_launcher_class = "org.springframework.boot.loader.launch.JarLauncher",
+    # Verify that dupe class checking works in this second springboot rule too
+    dupeclassescheck_enable = True,
+    dupeclassescheck_ignorelist = "demoapp_dupeclass_allowlist.txt",
     java_library = ":demoapp_lib",
     deps = [":rootclassloader_lib"],
 )


### PR DESCRIPTION
This PR adds a _validation output group to the springboot rule that includes the outputs of dupecheck, javaxdetect and banneddeps. This ensures that the springboot build fails when these checks fail.

The PR also changes the generated validation files to have unique filenames. This addresses some cases for "multiple springboot rules in the same package" that were not handled in #139.